### PR TITLE
fix(favorites): update item favorite state immediately after double press

### DIFF
--- a/components/Masonry.tsx
+++ b/components/Masonry.tsx
@@ -1,8 +1,10 @@
-import { MasonryFlashList } from "@shopify/flash-list";
+import { FlashList } from "@shopify/flash-list";
 import { useState } from "react";
 import type { ReactElement } from "react";
 import { View, Pressable, Text, StyleSheet, useWindowDimensions } from "react-native";
 
+import type { FavoriteSource } from "@/domain/entities/Favorite";
+import type { Season } from "@/domain/entities/Movie";
 import { Colors } from "@/constants/Colors";
 import { EmptyState } from "./EmptyState";
 import { MasonryItem } from "./MasonryItem";
@@ -12,6 +14,12 @@ export interface MasonryItemData {
   title: string;
   imageSrc?: string;
   mediaType?: "movie" | "series";
+  description?: string;
+  cast?: string[];
+  releaseDate?: string;
+  whereToWatch?: string[];
+  seasons?: Season[];
+  source?: FavoriteSource;
 }
 
 interface MasonryListProps {
@@ -25,6 +33,7 @@ interface MasonryListProps {
   recentlyAddedIds?: ReadonlySet<string>;
   onAddFavorite?: (item: MasonryItemData) => void;
   onRemoveFavorite?: (item: MasonryItemData) => void;
+  onOpenDetails?: (item: MasonryItemData) => void;
 }
 
 export default function MasonryList({
@@ -38,6 +47,7 @@ export default function MasonryList({
   recentlyAddedIds,
   onAddFavorite,
   onRemoveFavorite,
+  onOpenDetails,
 }: MasonryListProps): ReactElement {
   const [view, setView] = useState<"grid" | "list">("grid");
   const { width } = useWindowDimensions();
@@ -57,6 +67,12 @@ export default function MasonryList({
     return <EmptyState />;
   }
 
+  const favoriteMembershipKey = JSON.stringify({
+    favoriteIds: favoriteIds ? Array.from(favoriteIds).sort() : [],
+    recentlyAddedIds: recentlyAddedIds ? Array.from(recentlyAddedIds).sort() : [],
+    view,
+  });
+
   return (
     <View style={{ flex: 1, marginTop: offsetTop }}>
       {showLayoutToggle && width < 768 && (
@@ -75,18 +91,18 @@ export default function MasonryList({
           </Text>
         </Pressable>
       )}
-      <MasonryFlashList
+      <FlashList<MasonryItemData>
         numColumns={numColumns}
         style={{ flex: 1 }}
         contentContainerStyle={{
           paddingBottom: 96,
           paddingTop: topInset,
-          paddingHorizontal: 12,
+          paddingHorizontal: 16,
         }}
-        estimatedItemSize={view === "grid" ? 320 : 132}
-        keyExtractor={(item) => item.key}
+        keyExtractor={(item: MasonryItemData) => item.key}
         data={data}
-        renderItem={({ item, index }) => {
+        extraData={favoriteMembershipKey}
+        renderItem={({ item, index }: { item: MasonryItemData; index: number }) => {
           const isFavorite = favoriteIds?.has(item.key) || recentlyAddedIds?.has(item.key) || false;
 
           return (
@@ -96,6 +112,7 @@ export default function MasonryList({
               view={view}
               onAddFavorite={() => onAddFavorite?.(item)}
               onRemoveFavorite={() => onRemoveFavorite?.(item)}
+              onOpenDetails={() => onOpenDetails?.(item)}
               fallbackImage={fallbackImage}
               index={index}
             />

--- a/hooks/useFavoriteMutations.ts
+++ b/hooks/useFavoriteMutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { QueryKey } from "@tanstack/react-query";
 import { useRepositories } from "@/providers/RepositoryProvider";
-import type { FavoriteInput } from "@/domain/entities/Favorite";
+import type { Favorite, FavoriteInput, MediaType } from "@/domain/entities/Favorite";
 import { queryOptions } from "@/constants/query";
 
 interface UseFavoriteMutationsResult {
@@ -10,6 +11,15 @@ interface UseFavoriteMutationsResult {
   isRemoving: boolean;
 }
 
+type FavoriteQuerySnapshot = [QueryKey, Favorite[] | undefined];
+
+function matchesMediaType(
+  favorite: Pick<FavoriteInput, "mediaType">,
+  mediaType: MediaType | "all"
+): boolean {
+  return mediaType === "all" || favorite.mediaType === mediaType;
+}
+
 export function useFavoriteMutations(
   onAddSuccess?: (movieId: string) => void,
   onRemoveSuccess?: (movieId: string) => void,
@@ -17,23 +27,103 @@ export function useFavoriteMutations(
   const queryClient = useQueryClient();
   const { favoriteRepository } = useRepositories();
 
+  const getFavoriteSnapshots = (): FavoriteQuerySnapshot[] =>
+    queryClient.getQueriesData<Favorite[]>({
+      queryKey: queryOptions.movies.favorites.queryKey,
+    });
+
+  const restoreFavoriteSnapshots = (snapshots: FavoriteQuerySnapshot[]): void => {
+    snapshots.forEach(([queryKey, data]) => {
+      queryClient.setQueryData(queryKey, data);
+    });
+  };
+
+  const updateFavoriteQueries = (
+    updater: (favorites: Favorite[], mediaType: MediaType | "all") => Favorite[]
+  ): void => {
+    getFavoriteSnapshots().forEach(([queryKey, data]) => {
+      if (!data) {
+        return;
+      }
+
+      const mediaType =
+        queryKey.length >= 3 &&
+        (queryKey[2] === "movie" || queryKey[2] === "series" || queryKey[2] === "all")
+          ? queryKey[2]
+          : "all";
+
+      queryClient.setQueryData<Favorite[]>(queryKey, updater(data, mediaType));
+    });
+  };
+
   const { mutate: markAsFavorite, isPending: isAdding } = useMutation({
     mutationFn: (movie: FavoriteInput) => favoriteRepository.add(movie),
+    onMutate: async (favorite) => {
+      await queryClient.cancelQueries({
+        queryKey: queryOptions.movies.favorites.queryKey,
+      });
+
+      const snapshots = getFavoriteSnapshots();
+
+      updateFavoriteQueries((favorites, mediaType) => {
+        if (!matchesMediaType(favorite, mediaType)) {
+          return favorites;
+        }
+
+        if (favorites.some((item) => item.id === favorite.id)) {
+          return favorites;
+        }
+
+        return [
+          ...favorites,
+          {
+            ...favorite,
+            source: favorite.source || "catalog",
+            addedAt: new Date().toISOString(),
+          },
+        ];
+      });
+
+      return { snapshots };
+    },
     onSuccess: (_data, variables) => {
       onAddSuccess?.(variables.id);
       queryClient.invalidateQueries({
         queryKey: queryOptions.movies.favorites.queryKey,
       });
     },
+    onError: (_error, _variables, context) => {
+      if (context?.snapshots) {
+        restoreFavoriteSnapshots(context.snapshots);
+      }
+    },
   });
 
   const { mutate: removeFromFavorites, isPending: isRemoving } = useMutation({
     mutationFn: (movieId: string) => favoriteRepository.remove(movieId),
+    onMutate: async (movieId) => {
+      await queryClient.cancelQueries({
+        queryKey: queryOptions.movies.favorites.queryKey,
+      });
+
+      const snapshots = getFavoriteSnapshots();
+
+      updateFavoriteQueries((favorites) =>
+        favorites.filter((favorite) => favorite.id !== movieId)
+      );
+
+      return { snapshots };
+    },
     onSuccess: (_data, variables) => {
       onRemoveSuccess?.(variables);
       queryClient.invalidateQueries({
         queryKey: queryOptions.movies.favorites.queryKey,
       });
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.snapshots) {
+        restoreFavoriteSnapshots(context.snapshots);
+      }
     },
   });
 


### PR DESCRIPTION
## Summary
- Apply optimistic favorites updates so item state reflects immediately after double-press.
- Update list refresh behavior to keep favorite indicators in sync.

Closes #5