### PR TITLE
feat(search): allow query updates from results screen

### DIFF
--- a/components/views/SearchView.tsx
+++ b/components/views/SearchView.tsx
@@ -1,5 +1,5 @@
-import type { ReactElement } from "react";
-import { View, Text } from "react-native";
+import { useEffect, useState, type ReactElement } from "react";
+import { View, Text, TextInput, TouchableOpacity } from "react-native";
 
 import MasonryList, { type MasonryItemData } from "@/components/Masonry";
 import { Colors } from "@/constants/Colors";
@@ -10,9 +10,10 @@ interface SearchViewProps {
   errorMessage?: string;
   data: MasonryItemData[];
   favoriteIds: ReadonlySet<string>;
-  recentlyAddedIds: ReadonlySet<string>;
+  onSearchQuery: (query: string) => void;
   onAddFavorite: (item: MasonryItemData) => void;
   onRemoveFavorite: (item: MasonryItemData) => void;
+  onOpenDetails: (item: MasonryItemData) => void;
 }
 
 const palette = Colors.light;
@@ -23,13 +24,64 @@ export function SearchView({
   errorMessage,
   data,
   favoriteIds,
-  recentlyAddedIds,
+  onSearchQuery,
   onAddFavorite,
   onRemoveFavorite,
+  onOpenDetails,
 }: SearchViewProps): ReactElement {
+  const [searchDraft, setSearchDraft] = useState(query);
+
+  useEffect(() => {
+    setSearchDraft(query);
+  }, [query]);
+
+  const submitSearch = (): void => {
+    const nextQuery = searchDraft.trim();
+    if (!nextQuery || nextQuery === query) {
+      return;
+    }
+
+    onSearchQuery(nextQuery);
+  };
+
   if (isLoading) {
     return (
       <View style={{ backgroundColor: palette.shellBackground, flex: 1 }}>
+        <View
+          style={{
+            marginHorizontal: 16,
+            marginTop: 14,
+            marginBottom: 6,
+            minHeight: 44,
+            borderRadius: 14,
+            borderWidth: 1,
+            borderColor: palette.shellBorder,
+            backgroundColor: palette.shellSurface,
+            flexDirection: "row",
+            alignItems: "center",
+            paddingHorizontal: 10,
+            gap: 8,
+          }}
+        >
+          <TextInput
+            value={searchDraft}
+            onChangeText={setSearchDraft}
+            style={{ flex: 1, color: palette.text, fontSize: 15 }}
+            placeholder="Search titles"
+            placeholderTextColor={palette.shellMutedText}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="search"
+            onSubmitEditing={submitSearch}
+          />
+          <TouchableOpacity
+            onPress={submitSearch}
+            accessibilityRole="button"
+            accessibilityLabel="Submit search"
+          >
+            <Text style={{ color: palette.shellMutedText, fontWeight: "600" }}>Search</Text>
+          </TouchableOpacity>
+        </View>
         <View style={{ flex: 1, justifyContent: "center", alignItems: "center", padding: 20 }}>
           <Text style={{ color: palette.text, fontSize: 18 }}>Searching for &quot;{query}&quot;...</Text>
         </View>
@@ -40,6 +92,41 @@ export function SearchView({
   if (errorMessage) {
     return (
       <View style={{ backgroundColor: palette.shellBackground, flex: 1 }}>
+        <View
+          style={{
+            marginHorizontal: 16,
+            marginTop: 14,
+            marginBottom: 6,
+            minHeight: 44,
+            borderRadius: 14,
+            borderWidth: 1,
+            borderColor: palette.shellBorder,
+            backgroundColor: palette.shellSurface,
+            flexDirection: "row",
+            alignItems: "center",
+            paddingHorizontal: 10,
+            gap: 8,
+          }}
+        >
+          <TextInput
+            value={searchDraft}
+            onChangeText={setSearchDraft}
+            style={{ flex: 1, color: palette.text, fontSize: 15 }}
+            placeholder="Search titles"
+            placeholderTextColor={palette.shellMutedText}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="search"
+            onSubmitEditing={submitSearch}
+          />
+          <TouchableOpacity
+            onPress={submitSearch}
+            accessibilityRole="button"
+            accessibilityLabel="Submit search"
+          >
+            <Text style={{ color: palette.shellMutedText, fontWeight: "600" }}>Search</Text>
+          </TouchableOpacity>
+        </View>
         <View style={{ flex: 1, justifyContent: "center", alignItems: "center", padding: 20 }}>
           <Text style={{ color: palette.text, fontSize: 18 }}>Error searching for &quot;{query}&quot;</Text>
           <Text style={{ color: palette.shellMutedText, fontSize: 14, marginTop: 10 }}>{errorMessage}</Text>
@@ -50,13 +137,48 @@ export function SearchView({
 
   return (
     <View style={{ backgroundColor: palette.shellBackground, flex: 1 }}>
+      <View
+        style={{
+          marginHorizontal: 16,
+          marginTop: 14,
+          marginBottom: 6,
+          minHeight: 44,
+          borderRadius: 14,
+          borderWidth: 1,
+          borderColor: palette.shellBorder,
+          backgroundColor: palette.shellSurface,
+          flexDirection: "row",
+          alignItems: "center",
+          paddingHorizontal: 10,
+          gap: 8,
+        }}
+      >
+        <TextInput
+          value={searchDraft}
+          onChangeText={setSearchDraft}
+          style={{ flex: 1, color: palette.text, fontSize: 15 }}
+          placeholder="Search titles"
+          placeholderTextColor={palette.shellMutedText}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="search"
+          onSubmitEditing={submitSearch}
+        />
+        <TouchableOpacity
+          onPress={submitSearch}
+          accessibilityRole="button"
+          accessibilityLabel="Submit search"
+        >
+          <Text style={{ color: palette.shellMutedText, fontWeight: "600" }}>Search</Text>
+        </TouchableOpacity>
+      </View>
       <MasonryList
         data={data}
         isFavorites={false}
         favoriteIds={favoriteIds}
-        recentlyAddedIds={recentlyAddedIds}
         onAddFavorite={onAddFavorite}
         onRemoveFavorite={onRemoveFavorite}
+        onOpenDetails={onOpenDetails}
       />
     </View>
   );

--- a/containers/SearchContainer.tsx
+++ b/containers/SearchContainer.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo, useState, type ReactElement } from "react";
+import { useNavigation, type NavigationProp } from "@react-navigation/native";
+import { useEffect, useMemo, useState, type ReactElement } from "react";
 
+import type { RootStackParamList } from "@/app/navigation/types";
 import { SearchView } from "@/components/views/SearchView";
 import { queryOptions } from "@/constants/query";
 import { useFavoriteMutations } from "@/hooks/useFavoriteMutations";
@@ -11,21 +13,18 @@ interface SearchContainerProps {
 }
 
 export function SearchContainer({ query }: SearchContainerProps): ReactElement {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const { movieRepository, favoriteRepository } = useRepositories();
-  const [recentlyAddedIds, setRecentlyAddedIds] = useState<Set<string>>(new Set());
-  const { addFavorite, removeFavorite } = useFavoriteMutations(
-    (movieId) => setRecentlyAddedIds((prev) => new Set(prev).add(movieId)),
-    (movieId) =>
-      setRecentlyAddedIds((prev) => {
-        const next = new Set(prev);
-        next.delete(movieId);
-        return next;
-      }),
-  );
+  const { addFavorite, removeFavorite } = useFavoriteMutations();
+  const [activeQuery, setActiveQuery] = useState(query);
+
+  useEffect(() => {
+    setActiveQuery(query);
+  }, [query]);
 
   const { data, isLoading, error } = useQuery({
-    ...queryOptions.movies.all(query),
-    queryFn: () => movieRepository.search(query),
+    ...queryOptions.movies.all(activeQuery),
+    queryFn: () => movieRepository.search(activeQuery),
   });
 
   const { data: favorites } = useQuery({
@@ -36,29 +35,57 @@ export function SearchContainer({ query }: SearchContainerProps): ReactElement {
   const favoriteIds = useMemo(() => new Set(favorites?.map((item) => item.id) ?? []), [favorites]);
   const mappedData =
     data?.titles?.map((item) => ({
-      key: item.id,
-      imageSrc: item.primaryImage?.url,
-      title: item.primaryTitle,
-      mediaType: (item.type?.toLowerCase().includes("tv") ? "series" : "movie") as "movie" | "series",
-    })) || [];
+        key: item.id,
+        imageSrc: item.primaryImage?.url,
+        title: item.primaryTitle,
+        mediaType: (item.type?.toLowerCase().includes("tv") ? "series" : "movie") as "movie" | "series",
+        description: item.plot,
+        cast: item.cast,
+        releaseDate: item.releaseDate || item.startYear?.toString(),
+        whereToWatch: item.whereToWatch,
+        seasons: item.seasons,
+      })) || [];
 
   return (
     <SearchView
-      query={query}
+      query={activeQuery}
       isLoading={isLoading}
       errorMessage={error?.message}
       data={mappedData}
       favoriteIds={favoriteIds}
-      recentlyAddedIds={recentlyAddedIds}
+      onSearchQuery={setActiveQuery}
       onAddFavorite={(item) =>
         addFavorite({
           id: item.key,
           title: item.title,
           mediaType: item.mediaType || "movie",
           url: item.imageSrc,
+          description: item.description || "No disponible",
+          cast: item.cast && item.cast.length > 0 ? item.cast : ["No disponible"],
+          releaseDate: item.releaseDate || "No disponible",
+          whereToWatch:
+            item.whereToWatch && item.whereToWatch.length > 0
+              ? item.whereToWatch
+              : ["No disponible"],
+          seasons: item.seasons,
+          source: "catalog",
         })
       }
       onRemoveFavorite={(item) => removeFavorite(item.key)}
+      onOpenDetails={(item) =>
+        navigation.navigate("Details", {
+          id: item.key,
+          title: item.title,
+          mediaType: item.mediaType || "movie",
+          imageSrc: item.imageSrc,
+          description: item.description,
+          cast: item.cast,
+          releaseDate: item.releaseDate,
+          whereToWatch: item.whereToWatch,
+          seasons: item.seasons,
+          source: "catalog",
+        })
+      }
     />
   );
 }


### PR DESCRIPTION
## Summary
- Add an inline query input on the search results view.
- Allow submitting a new query without leaving the results route.
- Keep details/favorites interactions available after in-place query updates.

Closes #14