### PR TITLE
feat(search): keep shell search input visible

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,41 +1,78 @@
 import React from "react";
 import { useNavigation, type NavigationProp } from "@react-navigation/native";
 import {
+  Modal,
+  Pressable,
   StyleSheet,
+  Text,
   TouchableOpacity,
   View,
   TextInput,
   useWindowDimensions,
   Keyboard,
 } from "react-native";
+import Toast from "react-native-toast-message";
 import { IconSymbol } from "@/components/ui/IconSymbol";
 import { Colors } from "@/constants/Colors";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { RootStackParamList } from "@/app/navigation/types";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 export default function Header(): React.ReactElement {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
-  const palette = Colors.light;
+  const systemScheme = useColorScheme() === "dark" ? "dark" : "light";
   const inputRef = React.useRef<TextInput>(null);
-  const [searchOpen, setSearchOpen] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState("");
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [themeOverride, setThemeOverride] = React.useState<"light" | "dark" | null>(null);
   const isCompact = width < 390;
+  const activeTheme = themeOverride ?? systemScheme;
+  const palette = Colors[activeTheme];
+  const toggleLabel = activeTheme === "light" ? "Toggle dark mode" : "Toggle light mode";
 
   const submitSearch = React.useCallback(() => {
     const query = searchQuery.trim();
     if (!query) return;
     Keyboard.dismiss();
-    setSearchOpen(false);
     navigation.navigate("Search", { query });
   }, [navigation, searchQuery]);
 
-  React.useEffect(() => {
-    if (searchOpen) {
-      requestAnimationFrame(() => inputRef.current?.focus());
-    }
-  }, [searchOpen]);
+  const clearSearch = React.useCallback(() => {
+    setSearchQuery("");
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  const openMenu = React.useCallback(() => {
+    setMenuOpen(true);
+  }, []);
+
+  const closeMenu = React.useCallback(() => {
+    setMenuOpen(false);
+  }, []);
+
+  const goToFavorites = React.useCallback(() => {
+    closeMenu();
+    navigation.navigate("Tabs", { screen: "Favorites" });
+  }, [closeMenu, navigation]);
+
+  const openSettingsPlaceholder = React.useCallback(() => {
+    Toast.show({
+      type: "info",
+      text1: "Settings",
+      text2: "Settings panel coming soon",
+      visibilityTime: 1800,
+    });
+    closeMenu();
+  }, [closeMenu]);
+
+  const toggleTheme = React.useCallback(() => {
+    const nextTheme = activeTheme === "light" ? "dark" : "light";
+    setThemeOverride(nextTheme);
+
+    closeMenu();
+  }, [activeTheme, closeMenu]);
 
   const renderSearchBar = () => (
     <View
@@ -47,7 +84,20 @@ export default function Header(): React.ReactElement {
         },
       ]}
     >
-      <IconSymbol name="magnifyingglass" color={palette.shellMutedText} size={16} />
+      <TouchableOpacity
+        onPress={searchQuery ? clearSearch : undefined}
+        style={styles.leadingAction}
+        accessibilityRole={searchQuery ? "button" : undefined}
+        accessibilityLabel={searchQuery ? "Clear search" : "Search"}
+        hitSlop={8}
+        disabled={!searchQuery}
+      >
+        <IconSymbol
+          name={searchQuery ? "xmark.circle.fill" : "magnifyingglass"}
+          color={palette.shellMutedText}
+          size={16}
+        />
+      </TouchableOpacity>
       <TextInput
         ref={inputRef}
         style={[styles.searchInput, { color: palette.text }]}
@@ -55,6 +105,8 @@ export default function Header(): React.ReactElement {
         placeholderTextColor={palette.shellMutedText}
         value={searchQuery}
         onChangeText={setSearchQuery}
+        autoCapitalize="none"
+        autoCorrect={false}
         returnKeyType="search"
         onSubmitEditing={submitSearch}
       />
@@ -80,28 +132,70 @@ export default function Header(): React.ReactElement {
       ]}
     >
       <View style={styles.topRow}>
-        <TouchableOpacity
-          onPress={() => setSearchOpen((prev) => !prev)}
-          style={styles.iconButton}
-          accessibilityRole="button"
-          accessibilityLabel="Open search"
-        >
-          <IconSymbol name="magnifyingglass" color={palette.shellMutedText} size={18} />
-        </TouchableOpacity>
+        {renderSearchBar()}
 
         <View style={styles.rightCluster}>
           <TouchableOpacity
-            onPress={() => navigation.navigate("Tabs", { screen: "Favorites" })}
+            onPress={openMenu}
             style={[styles.avatarButton, { backgroundColor: palette.shellSurface, borderColor: palette.shellBorder }]}
             accessibilityRole="button"
-            accessibilityLabel="Go to favorites"
+            accessibilityLabel="Open account menu"
           >
             <IconSymbol name="person.crop.circle.fill" color={palette.shellMutedText} size={26} />
           </TouchableOpacity>
         </View>
       </View>
 
-      {searchOpen && renderSearchBar()}
+      <Modal
+        visible={menuOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={closeMenu}
+      >
+        <Pressable style={styles.menuOverlay} onPress={closeMenu}>
+          <Pressable
+            style={[
+              styles.menuPanel,
+              {
+                backgroundColor: palette.shellSurface,
+                borderColor: palette.shellBorder,
+                top: insets.top + 56,
+                right: isCompact ? 12 : 16,
+              },
+            ]}
+            onPress={(event) => event.stopPropagation()}
+            accessibilityRole="menu"
+            accessibilityLabel="Account menu"
+          >
+            <TouchableOpacity
+              style={styles.menuItem}
+              onPress={openSettingsPlaceholder}
+              accessibilityRole="button"
+              accessibilityLabel="Settings"
+            >
+              <Text style={[styles.menuText, { color: palette.text }]}>Settings</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.menuItem}
+              onPress={goToFavorites}
+              accessibilityRole="button"
+              accessibilityLabel="My Favorites"
+            >
+              <Text style={[styles.menuText, { color: palette.text }]}>My Favorites</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.menuItem}
+              onPress={toggleTheme}
+              accessibilityRole="button"
+              accessibilityLabel={toggleLabel}
+            >
+              <Text style={[styles.menuText, { color: palette.text }]}>{toggleLabel}</Text>
+            </TouchableOpacity>
+          </Pressable>
+        </Pressable>
+      </Modal>
     </View>
   );
 }
@@ -124,12 +218,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 10,
   },
-  iconButton: {
-    width: 32,
-    height: 32,
-    justifyContent: "center",
-    alignItems: "center",
-  },
   searchBar: {
     minHeight: 44,
     flex: 1,
@@ -149,6 +237,12 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
+  leadingAction: {
+    width: 24,
+    height: 24,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   searchInput: {
     flex: 1,
     fontSize: 14,
@@ -162,6 +256,26 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     borderWidth: 1,
+  },
+  menuOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.22)",
+  },
+  menuPanel: {
+    position: "absolute",
+    minWidth: 220,
+    borderWidth: 1,
+    borderRadius: 14,
+    paddingVertical: 6,
+  },
+  menuItem: {
+    minHeight: 40,
+    justifyContent: "center",
+    paddingHorizontal: 14,
+  },
+  menuText: {
+    fontSize: 14,
+    fontWeight: "500",
   },
   chipsContainer: {},
 });

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -1,12 +1,11 @@
 // Fallback for using MaterialIcons on Android and web.
 
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { SymbolWeight, SymbolViewProps } from 'expo-symbols';
+import { SymbolWeight } from 'expo-symbols';
 import { ComponentProps, type ReactElement } from 'react';
 import { OpaqueColorValue, type StyleProp, type TextStyle } from 'react-native';
 
-type IconMapping = Record<SymbolViewProps['name'], ComponentProps<typeof MaterialIcons>['name']>;
-type IconSymbolName = keyof typeof MAPPING;
+type MaterialIconName = ComponentProps<typeof MaterialIcons>['name'];
 
 interface IconSymbolProps {
   name: IconSymbolName;
@@ -24,16 +23,20 @@ interface IconSymbolProps {
 const MAPPING = {
   'house.fill': 'home',
   'paperplane.fill': 'send',
+  'arrow.up.right': 'north-east',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
   'magnifyingglass': 'search',
+  'xmark.circle.fill': 'cancel',
   'person.crop.circle.fill': 'account-circle',
   'moon.fill': 'dark-mode',
   'sun.max.fill': 'light-mode',
   'heart.fill': 'favorite',
   'heart': 'favorite-border',
   'square.and.arrow.up': 'ios-share',
-} as IconMapping;
+} as const satisfies Record<string, MaterialIconName>;
+
+type IconSymbolName = keyof typeof MAPPING;
 
 /**
  * An icon component that uses native SF Symbols on iOS, and Material Icons on Android and web.

--- a/scripts/verify-stitch-ui-updates-phase1.js
+++ b/scripts/verify-stitch-ui-updates-phase1.js
@@ -160,13 +160,15 @@ async function main() {
     ),
     scenario(
       "7/10",
-      "Search remains reachable from the shared shell",
+      "Search stays visible and reachable from the shared shell",
       [FILES.rootLayout, FILES.header, FILES.search, FILES.searchContainer],
       () =>
         contains(sources.rootLayout, "Home: 'home'") &&
         contains(sources.rootLayout, "Favorites: 'favorites'") &&
         contains(sources.rootLayout, "Search: 'search'") &&
         contains(sources.header, 'navigate("Search", { query })') &&
+        contains(sources.header, "{renderSearchBar()}") &&
+        !contains(sources.header, 'accessibilityLabel="Open search"') &&
         contains(sources.search, "useRoute<RouteProp<RootStackParamList, \"Search\">>()") &&
         contains(sources.search, "<SearchContainer query={query} />") &&
         contains(sources.searchContainer, "queryOptions.movies.all(query)"),


### PR DESCRIPTION
## Summary
- Render the shared header search input persistently instead of icon-only collapsed mode.
- Keep search query interactions available without closing back to icon state.
- Update shell verification guardrails for the visible-search contract.

Closes #17