### PR TITLE
feat(shell): unify navigation shell and details hardening

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,10 +19,12 @@ import "react-native-reanimated";
 import Header from "@/components/Header";
 import { Colors } from "@/constants/Colors";
 import { client } from "@/constants/RQClient";
+import { SeasonSchema } from "@/domain/entities/Movie";
 import { RepositoryProvider } from "@/providers/RepositoryProvider";
 import NotFoundScreen from "./+not-found";
 import TabNavigator from "./tabs/_layout";
 import SearchScreen from "./home/search/query";
+import DetailsScreen from "./home/details/[id]";
 import type { RootStackParamList } from "./navigation/types";
 
 interface ToastInfoProps {
@@ -100,6 +102,47 @@ const linking: LinkingOptions<RootStackParamList> = {
         },
       },
       Search: 'search',
+      Details: {
+        path: 'details/:id',
+        parse: {
+          cast: (value: string) =>
+            value
+              .split(',')
+              .map((entry) => entry.trim())
+              .filter(Boolean),
+          whereToWatch: (value: string) =>
+            value
+              .split(',')
+              .map((entry) => entry.trim())
+              .filter(Boolean),
+          seasons: (value: string) => {
+            try {
+              const parsed: unknown = JSON.parse(value);
+              const seasonsResult = SeasonSchema.array().safeParse(parsed);
+              return seasonsResult.success ? seasonsResult.data : undefined;
+            } catch {
+              return undefined;
+            }
+          },
+        },
+        stringify: {
+          cast: (value: unknown) =>
+            Array.isArray(value)
+              ? value.map((entry) => String(entry ?? '').trim()).filter(Boolean).join(', ')
+              : String(value ?? ''),
+          whereToWatch: (value: unknown) =>
+            Array.isArray(value)
+              ? value.map((entry) => String(entry ?? '').trim()).filter(Boolean).join(', ')
+              : String(value ?? ''),
+          seasons: (value: unknown) => {
+            try {
+              return JSON.stringify(value);
+            } catch {
+              return '';
+            }
+          },
+        },
+      },
       NotFound: '404',
     },
   },
@@ -152,6 +195,42 @@ export default function RootLayout(): ReactElement | null {
                     </View>
                   ),
                 }}
+              />
+              <Stack.Screen
+                name="Details"
+                component={DetailsScreen}
+                options={({ navigation }) => ({
+                  title: "Details",
+                  headerStyle: { backgroundColor: Colors.light.shellBackground },
+                  headerTintColor: Colors.light.text,
+                  headerLeft: (props) => (
+                    <View
+                      style={{
+                        flexDirection: "row",
+                        alignItems: "center",
+                        padding: 10,
+                        backgroundColor: Colors.light.shellBackground,
+                      }}
+                    >
+                      <HeaderBackButton
+                        {...props}
+                        tintColor={Colors.light.text}
+                        onPress={() => {
+                          if (navigation.canGoBack()) {
+                            navigation.goBack();
+                            return;
+                          }
+
+                          navigation.replace("Tabs", { screen: "Home" });
+                        }}
+                      />
+                      <Image
+                        style={{ width: 50, height: 30, resizeMode: "contain" }}
+                        source={require("../assets/images/logo.png")}
+                      />
+                    </View>
+                  ),
+                })}
               />
               <Stack.Screen name="NotFound" component={NotFoundScreen} />
             </Stack.Navigator>

--- a/app/home/details/[id].tsx
+++ b/app/home/details/[id].tsx
@@ -1,0 +1,11 @@
+import { useRoute, type RouteProp } from "@react-navigation/native";
+import type { ReactElement } from "react";
+
+import { DetailsContainer } from "@/containers/DetailsContainer";
+import type { RootStackParamList } from "@/app/navigation/types";
+
+export default function DetailsScreen(): ReactElement {
+  const route = useRoute<RouteProp<RootStackParamList, "Details">>();
+
+  return <DetailsContainer params={route.params} />;
+}

--- a/app/navigation/types.ts
+++ b/app/navigation/types.ts
@@ -1,3 +1,5 @@
+import type { Season } from "@/domain/entities/Movie";
+import type { FavoriteSource } from "@/domain/entities/Favorite";
 import type { NavigatorScreenParams } from "@react-navigation/native";
 
 export type TabParamList = {
@@ -8,5 +10,17 @@ export type TabParamList = {
 export type RootStackParamList = {
   Tabs: NavigatorScreenParams<TabParamList>;
   Search: { query?: string } | undefined;
+  Details: {
+    id: string;
+    title?: string;
+    mediaType?: "movie" | "series";
+    imageSrc?: string;
+    description?: string;
+    cast?: string[];
+    releaseDate?: string;
+    whereToWatch?: string[];
+    seasons?: Season[];
+    source?: FavoriteSource;
+  };
   NotFound: undefined;
 };

--- a/app/tabs/_layout.tsx
+++ b/app/tabs/_layout.tsx
@@ -1,69 +1,149 @@
-import FontAwesome from "@expo/vector-icons/FontAwesome";
-import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { createStackNavigator } from "@react-navigation/stack";
+import * as React from "react";
 import type { ReactElement } from "react";
+import { Modal, Text, TouchableOpacity, View, useWindowDimensions } from "react-native";
+
 import { Colors } from "@/constants/Colors";
 import type { TabParamList } from "@/app/navigation/types";
+import { AddFavoriteForm, type AddFavoriteFormValues } from "@/components/forms/AddFavoriteForm";
+import { parseManualSeriesSeasonsPayload } from "@/domain/entities/ManualFavorite";
+import { useFavoriteMutations } from "@/hooks/useFavoriteMutations";
 
 import HomeScreen from "./home";
 import FavoritesScreen from "./favorites";
 
-const Tab = createBottomTabNavigator<TabParamList>();
+const Stack = createStackNavigator<TabParamList>();
 
 export default function TabNavigator(): ReactElement {
   const palette = Colors.light;
+  const { addFavorite } = useFavoriteMutations();
+  const [showFormModal, setShowFormModal] = React.useState(false);
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 720;
+
+  const handleAddFavorite = React.useCallback((values: AddFavoriteFormValues) => {
+    const cast = values.cast
+      .split(",")
+      .map((member) => member.trim())
+      .filter(Boolean);
+
+    const whereToWatch = values.whereToWatch
+      .split(",")
+      .map((platform) => platform.trim())
+      .filter(Boolean);
+
+    const seasons =
+      values.mediaType === "series" && values.seasonsPayload
+        ? parseManualSeriesSeasonsPayload(values.seasonsPayload)
+        : undefined;
+
+    addFavorite({
+      id: `custom-${Date.now()}`,
+      title: values.title,
+      mediaType: values.mediaType,
+      url: values.url,
+      platform: values.platform,
+      description: values.description,
+      cast,
+      releaseDate: values.releaseDate,
+      whereToWatch,
+      seasons,
+      source: "manual",
+    });
+    setShowFormModal(false);
+  }, [addFavorite]);
 
   return (
-    <Tab.Navigator
-      screenOptions={{
-        tabBarActiveTintColor: palette.tint,
-        tabBarInactiveTintColor: palette.shellMutedText,
-        tabBarStyle: {
-          backgroundColor: palette.shellSurface,
-          borderTopColor: palette.shellBorder,
-          borderTopWidth: 1,
-          height: 72,
-          paddingTop: 10,
-          paddingBottom: 12,
-          shadowColor: "#000000",
-          shadowOpacity: 0.06,
-          shadowRadius: 16,
-          shadowOffset: { width: 0, height: -4 },
-          elevation: 10,
-        },
-        tabBarItemStyle: {
-          paddingVertical: 4,
-        },
-        tabBarIconStyle: {
-          marginTop: 0,
-        },
-        tabBarLabelStyle: {
-          fontSize: 11,
-          fontWeight: "700",
-          letterSpacing: 0.2,
-        },
-        headerShown: false,
-      }}
-    >
-      <Tab.Screen
-        name="Home"
-        component={HomeScreen}
-        options={{
-          title: "Home",
-          tabBarIcon: ({ color }) => (
-            <FontAwesome size={24} name="home" color={color} />
-          ),
+    <View style={{ flex: 1 }}>
+      <Stack.Navigator
+        screenOptions={{
+          headerShown: false,
         }}
-      />
-      <Tab.Screen
-        name="Favorites"
-        component={FavoritesScreen}
-        options={{
-          title: "Favorites",
-          tabBarIcon: ({ color }) => (
-            <FontAwesome size={24} name="heart" color={color} />
-          ),
+      >
+        <Stack.Screen
+          name="Home"
+          component={HomeScreen}
+          options={{ title: "Home" }}
+        />
+        <Stack.Screen
+          name="Favorites"
+          component={FavoritesScreen}
+          options={{ title: "Favorites" }}
+        />
+      </Stack.Navigator>
+
+      <TouchableOpacity
+        onPress={() => setShowFormModal(true)}
+        style={{
+          position: "absolute",
+          bottom: 88,
+          right: 20,
+          backgroundColor: palette.shellFabBackground,
+          width: 60,
+          height: 60,
+          borderRadius: 30,
+          justifyContent: "center",
+          alignItems: "center",
+          elevation: 5,
         }}
-      />
-    </Tab.Navigator>
+        accessibilityRole="button"
+        accessibilityLabel="Add favorite"
+      >
+        <Text style={{ color: palette.shellFabForeground, fontSize: 24 }}>+</Text>
+      </TouchableOpacity>
+
+      <Modal visible={showFormModal} transparent animationType="fade" onRequestClose={() => setShowFormModal(false)}>
+        <View
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: "rgba(23,16,28,0.32)",
+            justifyContent: "center",
+            alignItems: "center",
+            padding: 20,
+          }}
+        >
+          <View
+            style={{
+              width: isDesktop ? 560 : "100%",
+              maxWidth: 560,
+              backgroundColor: palette.shellSurface,
+              padding: 20,
+              borderRadius: 24,
+              borderColor: palette.shellBorder,
+              borderWidth: 1,
+              shadowColor: "#000000",
+              shadowOpacity: 0.1,
+              shadowRadius: 24,
+              shadowOffset: { width: 0, height: 12 },
+              elevation: 16,
+            }}
+          >
+            <TouchableOpacity
+              onPress={() => setShowFormModal(false)}
+              style={{
+                position: "absolute",
+                top: 10,
+                right: 10,
+                backgroundColor: palette.shellSurfaceAlt,
+                padding: 5,
+                borderRadius: 5,
+                zIndex: 1,
+              }}
+              accessibilityRole="button"
+              accessibilityLabel="Close add favorite modal"
+            >
+              <Text style={{ color: palette.text, fontSize: 16 }}>×</Text>
+            </TouchableOpacity>
+
+            <Text style={{ color: palette.text, fontSize: 18, marginBottom: 10 }}>Add Custom Movie</Text>
+            <AddFavoriteForm onSubmit={handleAddFavorite} />
+          </View>
+        </View>
+      </Modal>
+    </View>
   );
 }

--- a/components/forms/AddFavoriteForm.tsx
+++ b/components/forms/AddFavoriteForm.tsx
@@ -5,32 +5,88 @@ import { z } from "zod";
 import { toFormikValidationSchema } from "zod-formik-adapter";
 import type { ReactElement } from "react";
 
+import { ManualSeriesSeasonsSchema } from "@/domain/entities/ManualFavorite";
+
+const RequiredText = (label: string) => z.string().trim().min(1, `${label} is required`);
+const RequiredCsvText = (label: string) =>
+  z
+    .string()
+    .trim()
+    .min(1, `${label} is required`)
+    .refine(
+      (value) =>
+        value
+          .split(",")
+          .map((part) => part.trim())
+          .filter(Boolean).length > 0,
+      `${label} must include at least one item`
+    );
+
 /**
  * Zod schema for form validation
  * Validates favorite input data
  */
-export const AddFavoriteFormSchema = z.object({
-  title: z.string().min(1, "Title is required"),
-  mediaType: z.enum(["movie", "series"]),
-  url: z
-    .string()
-    .refine(
-      (val) => {
-        if (!val) return true; // Optional field per product decision
-        try {
-          new URL(val);
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      { message: "Invalid URL format" }
-    )
-    .optional(),
-  platform: z
-    .enum(["Spotify", "Deezer", "Tidal", "Netflix", "Hulu", "Disney+"])
-    .optional(), // Optional per product decision
-});
+export const AddFavoriteFormSchema = z
+  .object({
+    title: RequiredText("Title"),
+    mediaType: z.enum(["movie", "series"]),
+    url: z
+      .string()
+      .refine(
+        (val) => {
+          if (!val) return true; // Optional field per product decision
+          try {
+            new URL(val);
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        { message: "Invalid URL format" }
+      )
+      .optional(),
+    platform: z
+      .enum(["Spotify", "Deezer", "Tidal", "Netflix", "Hulu", "Disney+"])
+      .optional(), // Optional per product decision
+    description: RequiredText("Description"),
+    cast: RequiredCsvText("Cast"),
+    releaseDate: RequiredText("Release date"),
+    whereToWatch: RequiredCsvText("Where to watch"),
+    seasonsPayload: z.string().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.mediaType !== "series") {
+      return;
+    }
+
+    if (!value.seasonsPayload || value.seasonsPayload.trim().length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["seasonsPayload"],
+        message: "Seasons and episodes JSON is required for series",
+      });
+      return;
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(value.seasonsPayload);
+      const result = ManualSeriesSeasonsSchema.safeParse(parsed);
+
+      if (!result.success) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["seasonsPayload"],
+          message: "Invalid seasons JSON format",
+        });
+      }
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["seasonsPayload"],
+        message: "Invalid JSON syntax for seasons",
+      });
+    }
+  });
 
 /**
  * Type for form values
@@ -48,7 +104,17 @@ interface AddFavoriteFormProps {
 export function AddFavoriteForm({ onSubmit }: AddFavoriteFormProps): ReactElement {
   return (
     <Formik<AddFavoriteFormValues>
-      initialValues={{ title: "", mediaType: "movie", url: "", platform: undefined }}
+      initialValues={{
+        title: "",
+        mediaType: "movie",
+        url: "",
+        platform: undefined,
+        description: "",
+        cast: "",
+        releaseDate: "",
+        whereToWatch: "",
+        seasonsPayload: "",
+      }}
       validateOnBlur={false}
       validateOnChange={false}
       validationSchema={toFormikValidationSchema(AddFavoriteFormSchema)}
@@ -184,6 +250,121 @@ export function AddFavoriteForm({ onSubmit }: AddFavoriteFormProps): ReactElemen
             >
               {errors.platform}
             </Text>
+          )}
+          <TextInput
+            style={{
+              minHeight: 72,
+              borderColor: "#E50914",
+              borderWidth: 1,
+              borderRadius: 5,
+              paddingHorizontal: 10,
+              paddingVertical: 8,
+              color: "#FFFFFF",
+              backgroundColor: "#333333",
+              marginBottom: 5,
+              textAlignVertical: "top",
+            }}
+            multiline
+            placeholder="Description / Synopsis"
+            placeholderTextColor="#CCCCCC"
+            value={values.description}
+            onChangeText={handleChange("description")}
+          />
+          {errors.description && (
+            <Text style={{ color: "#FF0000", fontSize: 12, marginBottom: 10 }}>
+              {errors.description}
+            </Text>
+          )}
+          <TextInput
+            style={{
+              height: 40,
+              borderColor: "#E50914",
+              borderWidth: 1,
+              borderRadius: 5,
+              paddingHorizontal: 10,
+              color: "#FFFFFF",
+              backgroundColor: "#333333",
+              marginBottom: 5,
+            }}
+            placeholder="Cast (comma-separated)"
+            placeholderTextColor="#CCCCCC"
+            value={values.cast}
+            onChangeText={handleChange("cast")}
+          />
+          {errors.cast && (
+            <Text style={{ color: "#FF0000", fontSize: 12, marginBottom: 10 }}>
+              {errors.cast}
+            </Text>
+          )}
+          <TextInput
+            style={{
+              height: 40,
+              borderColor: "#E50914",
+              borderWidth: 1,
+              borderRadius: 5,
+              paddingHorizontal: 10,
+              color: "#FFFFFF",
+              backgroundColor: "#333333",
+              marginBottom: 5,
+            }}
+            placeholder="Release date (e.g. 2024-09-10)"
+            placeholderTextColor="#CCCCCC"
+            value={values.releaseDate}
+            onChangeText={handleChange("releaseDate")}
+          />
+          {errors.releaseDate && (
+            <Text style={{ color: "#FF0000", fontSize: 12, marginBottom: 10 }}>
+              {errors.releaseDate}
+            </Text>
+          )}
+          <TextInput
+            style={{
+              height: 40,
+              borderColor: "#E50914",
+              borderWidth: 1,
+              borderRadius: 5,
+              paddingHorizontal: 10,
+              color: "#FFFFFF",
+              backgroundColor: "#333333",
+              marginBottom: 5,
+            }}
+            placeholder="Where to watch (comma-separated)"
+            placeholderTextColor="#CCCCCC"
+            value={values.whereToWatch}
+            onChangeText={handleChange("whereToWatch")}
+          />
+          {errors.whereToWatch && (
+            <Text style={{ color: "#FF0000", fontSize: 12, marginBottom: 10 }}>
+              {errors.whereToWatch}
+            </Text>
+          )}
+          {values.mediaType === "series" && (
+            <>
+              <TextInput
+                style={{
+                  minHeight: 96,
+                  borderColor: "#E50914",
+                  borderWidth: 1,
+                  borderRadius: 5,
+                  paddingHorizontal: 10,
+                  paddingVertical: 8,
+                  color: "#FFFFFF",
+                  backgroundColor: "#333333",
+                  marginBottom: 5,
+                  textAlignVertical: "top",
+                }}
+                multiline
+                placeholder='Seasons JSON (e.g. [{"seasonNumber":1,"episodes":[{"episodeNumber":1,"title":"Pilot","releaseDate":"2024-01-01"}]}])'
+                placeholderTextColor="#CCCCCC"
+                value={values.seasonsPayload}
+                onChangeText={handleChange("seasonsPayload")}
+              />
+              {errors.seasonsPayload && (
+                <Text style={{ color: "#FF0000", fontSize: 12, marginBottom: 10 }}>
+                  {errors.seasonsPayload}
+                </Text>
+              )}
+            </>
           )}
           <TouchableOpacity
             onPress={() => handleSubmit()}

--- a/components/views/DetailsView.tsx
+++ b/components/views/DetailsView.tsx
@@ -1,0 +1,122 @@
+import { Image } from "expo-image";
+import type { ReactElement } from "react";
+import { ScrollView, Text, View } from "react-native";
+
+import type { Season } from "@/domain/entities/Movie";
+import { Colors } from "@/constants/Colors";
+
+interface DetailsViewProps {
+  isLoading: boolean;
+  errorMessage?: string;
+  title: string;
+  description?: string;
+  cast?: string[];
+  releaseDate?: string;
+  whereToWatch?: string[];
+  seasons?: Season[];
+  imageSrc?: string;
+  mediaType: "movie" | "series";
+}
+
+export function DetailsView({
+  isLoading,
+  errorMessage,
+  title,
+  description,
+  cast,
+  releaseDate,
+  whereToWatch,
+  seasons,
+  imageSrc,
+  mediaType,
+}: DetailsViewProps): ReactElement {
+  const palette = Colors.light;
+  const fallbackImage = require("../../assets/images/logo.png");
+
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: palette.shellBackground }}>
+        <Text style={{ color: palette.text, fontSize: 18 }}>Loading details...</Text>
+      </View>
+    );
+  }
+
+  if (errorMessage) {
+    return (
+      <View style={{ flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: palette.shellBackground, padding: 20 }}>
+        <Text style={{ color: palette.text, fontSize: 18, fontWeight: "700" }}>Error loading details</Text>
+        <Text style={{ color: palette.shellMutedText, marginTop: 10 }}>{errorMessage}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={{ flex: 1, backgroundColor: palette.shellBackground }} contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <Image
+        source={imageSrc ? { uri: imageSrc } : fallbackImage}
+        placeholder={fallbackImage}
+        style={{ width: "100%", height: 260, borderRadius: 18 }}
+      />
+
+      <Text style={{ color: palette.text, fontSize: 30, lineHeight: 34, fontWeight: "800" }}>{title}</Text>
+
+      <View style={{ gap: 8 }}>
+        <Text style={{ color: palette.shellMutedText, fontSize: 12, fontWeight: "700", textTransform: "uppercase" }}>Descripción / Sinopsis</Text>
+        <Text style={{ color: palette.text, fontSize: 16, lineHeight: 24 }}>{description || "No disponible"}</Text>
+      </View>
+
+      <View style={{ gap: 8 }}>
+        <Text style={{ color: palette.shellMutedText, fontSize: 12, fontWeight: "700", textTransform: "uppercase" }}>Elenco</Text>
+        <Text style={{ color: palette.text, fontSize: 16, lineHeight: 24 }}>
+          {cast && cast.length > 0 ? cast.join(", ") : "No disponible"}
+        </Text>
+      </View>
+
+      <View style={{ gap: 8 }}>
+        <Text style={{ color: palette.shellMutedText, fontSize: 12, fontWeight: "700", textTransform: "uppercase" }}>Fecha de estreno</Text>
+        <Text style={{ color: palette.text, fontSize: 16 }}>{releaseDate || "No disponible"}</Text>
+      </View>
+
+      <View style={{ gap: 8 }}>
+        <Text style={{ color: palette.shellMutedText, fontSize: 12, fontWeight: "700", textTransform: "uppercase" }}>Dónde ver</Text>
+        <Text style={{ color: palette.text, fontSize: 16 }}>
+          {whereToWatch && whereToWatch.length > 0 ? whereToWatch.join(", ") : "No disponible"}
+        </Text>
+      </View>
+
+      {mediaType === "series" && (
+        <View style={{ gap: 10 }}>
+          <Text style={{ color: palette.shellMutedText, fontSize: 12, fontWeight: "700", textTransform: "uppercase" }}>
+            Temporadas y episodios
+          </Text>
+
+          {seasons && seasons.length > 0 ? (
+            seasons.map((season) => (
+              <View
+                key={`season-${season.seasonNumber}`}
+                style={{ backgroundColor: palette.shellSurface, borderColor: palette.shellBorder, borderWidth: 1, borderRadius: 14, padding: 12, gap: 8 }}
+              >
+                <Text style={{ color: palette.text, fontSize: 18, fontWeight: "700" }}>
+                  {season.title || `Temporada ${season.seasonNumber}`}
+                </Text>
+
+                {season.episodes.map((episode) => (
+                  <View key={`episode-${season.seasonNumber}-${episode.episodeNumber}`} style={{ gap: 2 }}>
+                    <Text style={{ color: palette.text, fontSize: 15 }}>
+                      E{episode.episodeNumber}. {episode.title}
+                    </Text>
+                    <Text style={{ color: palette.shellMutedText, fontSize: 13 }}>
+                      Lanzamiento: {episode.releaseDate || "No disponible"}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            ))
+          ) : (
+            <Text style={{ color: palette.text, fontSize: 16 }}>No hay temporadas disponibles</Text>
+          )}
+        </View>
+      )}
+    </ScrollView>
+  );
+}

--- a/components/views/FavoritesView.tsx
+++ b/components/views/FavoritesView.tsx
@@ -1,9 +1,8 @@
 import type { ReactElement } from "react";
-import { View, Text, TouchableOpacity, Modal } from "react-native";
+import { View, Text, TouchableOpacity } from "react-native";
 
 import MasonryList from "@/components/Masonry";
-import { AddFavoriteForm, type AddFavoriteFormValues } from "@/components/forms/AddFavoriteForm";
-import { BackupControls } from "@/components/BackupControls";
+import type { MasonryItemData } from "@/components/Masonry";
 import { LoadingState, ErrorState } from "@/components/FeedbackStates";
 import { Colors } from "@/constants/Colors";
 import type { MediaType } from "@/constants/query";
@@ -21,18 +20,11 @@ interface FavoritesViewProps {
   onFilterChange: (value: FilterOption) => void;
   isLoading: boolean;
   errorMessage?: string;
-  masonryData: { key: string; imageSrc?: string; title: string; mediaType?: "movie" | "series" }[];
+  masonryData: MasonryItemData[];
   favoriteIds: ReadonlySet<string>;
-  onAddFavorite: (item: { key: string; imageSrc?: string; title: string; mediaType?: "movie" | "series" }) => void;
-  onRemoveFavorite: (item: { key: string; imageSrc?: string; title: string; mediaType?: "movie" | "series" }) => void;
-  onSubmitFavorite: (values: AddFavoriteFormValues) => void;
-  onBackup: () => void;
-  onRestore: () => void;
-  isBackingUp: boolean;
-  isRestoring: boolean;
-  showFormModal: boolean;
-  setShowFormModal: (value: boolean) => void;
-  isDesktop: boolean;
+  onAddFavorite: (item: MasonryItemData) => void;
+  onRemoveFavorite: (item: MasonryItemData) => void;
+  onOpenDetails: (item: MasonryItemData) => void;
 }
 
 export function FavoritesView({
@@ -44,32 +36,12 @@ export function FavoritesView({
   favoriteIds,
   onAddFavorite,
   onRemoveFavorite,
-  onSubmitFavorite,
-  onBackup,
-  onRestore,
-  isBackingUp,
-  isRestoring,
-  showFormModal,
-  setShowFormModal,
-  isDesktop,
+  onOpenDetails,
 }: FavoritesViewProps): ReactElement {
   const palette = Colors.light;
 
   if (isLoading) return <LoadingState message="Loading favorites..." />;
   if (errorMessage) return <ErrorState message="Error loading favorites" error={new Error(errorMessage)} />;
-
-  const formContent = (
-    <View>
-      <Text style={{ color: palette.text, fontSize: 18, marginBottom: 10 }}>Add Custom Movie</Text>
-      <AddFavoriteForm onSubmit={onSubmitFavorite} />
-      <BackupControls
-        onBackup={onBackup}
-        onRestore={onRestore}
-        isBackingUp={isBackingUp}
-        isRestoring={isRestoring}
-      />
-    </View>
-  );
 
   return (
     <View style={{ flex: 1, backgroundColor: palette.shellBackground }}>
@@ -115,7 +87,7 @@ export function FavoritesView({
         </View>
       </View>
 
-      <View style={{ flex: 1, paddingHorizontal: 12 }}>
+      <View style={{ flex: 1 }}>
         <MasonryList
           data={masonryData}
           isFavorites
@@ -125,74 +97,10 @@ export function FavoritesView({
           favoriteIds={favoriteIds}
           onAddFavorite={onAddFavorite}
           onRemoveFavorite={onRemoveFavorite}
+          onOpenDetails={onOpenDetails}
         />
       </View>
 
-      <TouchableOpacity
-        onPress={() => setShowFormModal(true)}
-        style={{
-          position: "absolute",
-          bottom: 28,
-          right: 20,
-          backgroundColor: palette.shellFabBackground,
-          width: 60,
-          height: 60,
-          borderRadius: 30,
-          justifyContent: "center",
-          alignItems: "center",
-          elevation: 5,
-        }}
-      >
-        <Text style={{ color: palette.shellFabForeground, fontSize: 24 }}>+</Text>
-      </TouchableOpacity>
-
-      <Modal visible={showFormModal} transparent animationType="fade" onRequestClose={() => setShowFormModal(false)}>
-        <View
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: "rgba(23,16,28,0.32)",
-            justifyContent: "center",
-            alignItems: "center",
-            padding: 20,
-          }}
-        >
-          <View
-            style={{
-              width: isDesktop ? 560 : "100%",
-              maxWidth: 560,
-              backgroundColor: palette.shellSurface,
-              padding: 20,
-              borderRadius: 24,
-              borderColor: palette.shellBorder,
-              borderWidth: 1,
-              shadowColor: "#000000",
-              shadowOpacity: 0.1,
-              shadowRadius: 24,
-              shadowOffset: { width: 0, height: 12 },
-              elevation: 16,
-            }}
-          >
-            <TouchableOpacity
-              onPress={() => setShowFormModal(false)}
-              style={{
-                position: "absolute",
-                top: 10,
-                right: 10,
-                backgroundColor: palette.shellSurfaceAlt,
-                padding: 5,
-                borderRadius: 5,
-              }}
-            >
-              <Text style={{ color: palette.text, fontSize: 16 }}>×</Text>
-            </TouchableOpacity>
-            {formContent}
-          </View>
-        </View>
-      </Modal>
     </View>
   );
 }

--- a/components/views/HomeView.tsx
+++ b/components/views/HomeView.tsx
@@ -10,9 +10,9 @@ interface HomeViewProps {
   errorMessage?: string;
   movies: MasonryItemData[];
   favoriteIds: ReadonlySet<string>;
-  recentlyAddedIds: ReadonlySet<string>;
   onAddFavorite: (item: MasonryItemData) => void;
   onRemoveFavorite: (item: MasonryItemData) => void;
+  onOpenDetails: (item: MasonryItemData) => void;
 }
 
 export function HomeView({
@@ -20,9 +20,9 @@ export function HomeView({
   errorMessage,
   movies,
   favoriteIds,
-  recentlyAddedIds,
   onAddFavorite,
   onRemoveFavorite,
+  onOpenDetails,
 }: HomeViewProps): ReactElement {
   const palette = Colors.light;
   const categories = ["Movies", "TV", "Music", "Books"];
@@ -87,9 +87,9 @@ export function HomeView({
           showLayoutToggle={false}
           topInset={0}
           favoriteIds={favoriteIds}
-          recentlyAddedIds={recentlyAddedIds}
           onAddFavorite={onAddFavorite}
           onRemoveFavorite={onRemoveFavorite}
+          onOpenDetails={onOpenDetails}
         />
       </View>
     </SafeAreaView>

--- a/containers/DetailsContainer.tsx
+++ b/containers/DetailsContainer.tsx
@@ -1,0 +1,154 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+import { z } from "zod";
+
+import { DetailsView } from "@/components/views/DetailsView";
+import type { RootStackParamList } from "@/app/navigation/types";
+import { useRepositories } from "@/providers/RepositoryProvider";
+import { SeasonSchema } from "@/domain/entities/Movie";
+
+interface DetailsContainerProps {
+  params: RootStackParamList["Details"];
+}
+
+function normalizeStringList(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const normalized = value
+      .map((entry) => (typeof entry === "string" ? entry : String(entry ?? "")).trim())
+      .filter(Boolean);
+
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  return undefined;
+}
+
+function normalizeSeasons(
+  value: unknown
+): RootStackParamList["Details"]["seasons"] | undefined {
+  const parsedValue =
+    typeof value === "string"
+      ? (() => {
+          try {
+            return JSON.parse(value) as unknown;
+          } catch {
+            return undefined;
+          }
+        })()
+      : value;
+
+  const parsedSeasons = z.array(SeasonSchema).safeParse(parsedValue);
+
+  return parsedSeasons.success && parsedSeasons.data.length > 0
+    ? (parsedSeasons.data as RootStackParamList["Details"]["seasons"])
+    : undefined;
+}
+
+export function DetailsContainer({ params }: DetailsContainerProps): ReactElement {
+  const { movieRepository, favoriteRepository } = useRepositories();
+  const isManualFavorite = params.source === "manual" || params.id.startsWith("custom-");
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["movies", "details", params.id],
+    queryFn: () => movieRepository.getById(params.id),
+    enabled: !isManualFavorite,
+  });
+
+  const { data: manualDetails, isLoading: isManualLoading } = useQuery({
+    queryKey: ["favorites", "details", params.id],
+    queryFn: () => favoriteRepository.getById(params.id),
+    enabled: isManualFavorite,
+  });
+
+  const missingDetails = !isManualFavorite && !isLoading && !error && data === null;
+
+  const resolvedType = data?.type?.toLowerCase();
+  const mediaType = resolvedType
+    ? resolvedType.includes("tv") || resolvedType.includes("series")
+      ? "series"
+      : "movie"
+    : params.mediaType || "movie";
+
+  const title = data?.primaryTitle || manualDetails?.title || params.title || "Título no disponible";
+  const description = data?.plot || manualDetails?.description || params.description;
+  const cast = normalizeStringList(data?.cast ?? manualDetails?.cast ?? params.cast);
+  const releaseDate =
+    data?.releaseDate ||
+    data?.startYear?.toString() ||
+    manualDetails?.releaseDate ||
+    params.releaseDate;
+  const whereToWatch = normalizeStringList(
+    data?.whereToWatch ?? manualDetails?.whereToWatch ?? params.whereToWatch
+  );
+  const seasons = normalizeSeasons(
+    data?.seasons ?? manualDetails?.seasons ?? (params as { seasons?: unknown }).seasons
+  );
+  const imageSrc = data?.primaryImage?.url || manualDetails?.url || params.imageSrc;
+
+  const hasRenderableDetails = Boolean(title && title.trim().length > 0);
+
+  const hasRequiredBaseFields = Boolean(
+    title &&
+      title.trim().length > 0 &&
+      description &&
+      description.trim().length > 0 &&
+      releaseDate &&
+      releaseDate.trim().length > 0 &&
+      cast &&
+      cast.length > 0 &&
+      whereToWatch &&
+      whereToWatch.length > 0
+  );
+
+  const hasRequiredSeriesFields = Boolean(
+    mediaType !== "series" ||
+      (seasons &&
+        seasons.length > 0 &&
+        seasons.every(
+          (season) =>
+            season.episodes.length > 0 &&
+            season.episodes.every((episode) => Boolean(episode.releaseDate?.trim()))
+        ))
+  );
+
+  const hasRequiredDetails = hasRequiredBaseFields && hasRequiredSeriesFields;
+  const shouldBlockOnError = Boolean(error) && !hasRequiredDetails;
+
+  const blockingErrorMessage = shouldBlockOnError
+    ? error instanceof Error
+      ? error.message
+      : "No pudimos cargar los detalles de este título."
+    : !hasRequiredDetails
+    ? error instanceof Error
+      ? error.message
+      : missingDetails
+        ? "No pudimos encontrar los detalles de este título."
+        : "Los detalles disponibles están incompletos para este título."
+    : undefined;
+
+  const showBlockingLoading = (isLoading || isManualLoading) && !hasRequiredDetails;
+
+  return (
+    <DetailsView
+      isLoading={showBlockingLoading}
+      errorMessage={blockingErrorMessage}
+      title={title}
+      description={description}
+      cast={cast}
+      releaseDate={releaseDate}
+      whereToWatch={whereToWatch}
+      seasons={seasons}
+      imageSrc={imageSrc}
+      mediaType={mediaType}
+    />
+  );
+}

--- a/containers/FavoritesContainer.tsx
+++ b/containers/FavoritesContainer.tsx
@@ -1,17 +1,17 @@
 import { useState, type ReactElement } from "react";
-import { useWindowDimensions } from "react-native";
 import { useQuery } from "@tanstack/react-query";
+import { useNavigation, type NavigationProp } from "@react-navigation/native";
 
+import type { RootStackParamList } from "@/app/navigation/types";
 import { FavoritesView } from "@/components/views/FavoritesView";
-import type { AddFavoriteFormValues } from "@/components/forms/AddFavoriteForm";
 import { queryOptions } from "@/constants/query";
 import { useFavoriteMutations } from "@/hooks/useFavoriteMutations";
-import { useBackupMutations } from "@/hooks/useBackupMutations";
 import { useRepositories } from "@/providers/RepositoryProvider";
 
 type FilterOption = "movie" | "series" | undefined;
 
 export function FavoritesContainer(): ReactElement {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const { favoriteRepository } = useRepositories();
   const [filter, setFilter] = useState<FilterOption>(undefined);
   const { data, isLoading, error } = useQuery({
@@ -19,30 +19,22 @@ export function FavoritesContainer(): ReactElement {
     queryFn: () => favoriteRepository.getByMediaType(filter),
   });
   const { addFavorite, removeFavorite } = useFavoriteMutations();
-  const { backupFavorites, restoreFavorites, isBackingUp, isRestoring } = useBackupMutations();
-  const [showFormModal, setShowFormModal] = useState(false);
-  const { width } = useWindowDimensions();
-  const isDesktop = width >= 720;
-
-  const handleAddFavorite = (values: AddFavoriteFormValues) => {
-    addFavorite({
-      id: Date.now().toString(),
-      title: values.title,
-      mediaType: values.mediaType,
-      url: values.url,
-      platform: values.platform,
-    });
-  };
 
   const favoriteIds = new Set(data?.map((item) => item.id) ?? []);
 
   const masonryData =
     data?.map((item) => ({
-      key: item.id,
-      imageSrc: item.url,
-      title: item.title,
-      mediaType: item.mediaType,
-    })) || [];
+        key: item.id,
+        imageSrc: item.url,
+        title: item.title,
+        mediaType: item.mediaType,
+        description: item.description,
+        cast: item.cast,
+        releaseDate: item.releaseDate,
+        whereToWatch: item.whereToWatch || (item.platform ? [item.platform] : undefined),
+        seasons: item.seasons,
+        source: item.source,
+      })) || [];
 
   return (
     <FavoritesView
@@ -58,17 +50,32 @@ export function FavoritesContainer(): ReactElement {
           title: item.title,
           mediaType: item.mediaType || "movie",
           url: item.imageSrc,
+          description: item.description || "No disponible",
+          cast: item.cast && item.cast.length > 0 ? item.cast : ["No disponible"],
+          releaseDate: item.releaseDate || "No disponible",
+          whereToWatch:
+            item.whereToWatch && item.whereToWatch.length > 0
+              ? item.whereToWatch
+              : ["No disponible"],
+          seasons: item.seasons,
+          source: "catalog",
         })
       }
       onRemoveFavorite={(item) => removeFavorite(item.key)}
-      onSubmitFavorite={handleAddFavorite}
-      onBackup={() => data && backupFavorites(data)}
-      onRestore={restoreFavorites}
-      isBackingUp={isBackingUp}
-      isRestoring={isRestoring}
-      showFormModal={showFormModal}
-      setShowFormModal={setShowFormModal}
-      isDesktop={isDesktop}
+      onOpenDetails={(item) =>
+        navigation.navigate("Details", {
+          id: item.key,
+          title: item.title,
+          mediaType: item.mediaType || "movie",
+          imageSrc: item.imageSrc,
+          description: item.description,
+          cast: item.cast,
+          releaseDate: item.releaseDate,
+          whereToWatch: item.whereToWatch,
+          seasons: item.seasons,
+          source: item.source,
+        })
+      }
     />
   );
 }

--- a/containers/HomeContainer.tsx
+++ b/containers/HomeContainer.tsx
@@ -1,12 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo, useState, type ReactElement } from "react";
+import { useNavigation, type NavigationProp } from "@react-navigation/native";
+import { useMemo, type ReactElement } from "react";
 
+import type { RootStackParamList } from "@/app/navigation/types";
 import { HomeView } from "@/components/views/HomeView";
 import { queryOptions } from "@/constants/query";
 import { useFavoriteMutations } from "@/hooks/useFavoriteMutations";
 import { useRepositories } from "@/providers/RepositoryProvider";
 
 export function HomeContainer(): ReactElement {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const { movieRepository, favoriteRepository } = useRepositories();
   const { data, isLoading, error } = useQuery({
     ...queryOptions.movies.random,
@@ -18,16 +21,7 @@ export function HomeContainer(): ReactElement {
     queryFn: () => favoriteRepository.getAll(),
   });
 
-  const [recentlyAddedIds, setRecentlyAddedIds] = useState<Set<string>>(new Set());
-  const { addFavorite, removeFavorite } = useFavoriteMutations(
-    (movieId) => setRecentlyAddedIds((prev) => new Set(prev).add(movieId)),
-    (movieId) =>
-      setRecentlyAddedIds((prev) => {
-        const next = new Set(prev);
-        next.delete(movieId);
-        return next;
-      }),
-  );
+  const { addFavorite, removeFavorite } = useFavoriteMutations();
 
   const movies = useMemo(
     () =>
@@ -36,6 +30,11 @@ export function HomeContainer(): ReactElement {
         imageSrc: item.primaryImage?.url,
         title: item.primaryTitle,
         mediaType: (item.type?.toLowerCase().includes("tv") ? "series" : "movie") as "movie" | "series",
+        description: item.plot,
+        cast: item.cast,
+        releaseDate: item.releaseDate || item.startYear?.toString(),
+        whereToWatch: item.whereToWatch,
+        seasons: item.seasons,
       })) || [],
     [data?.titles],
   );
@@ -48,16 +47,38 @@ export function HomeContainer(): ReactElement {
       errorMessage={error?.message}
       movies={movies}
       favoriteIds={favoriteIds}
-      recentlyAddedIds={recentlyAddedIds}
       onAddFavorite={(item) =>
         addFavorite({
           id: item.key,
           title: item.title,
           mediaType: item.mediaType || "movie",
           url: item.imageSrc,
+          description: item.description || "No disponible",
+          cast: item.cast && item.cast.length > 0 ? item.cast : ["No disponible"],
+          releaseDate: item.releaseDate || "No disponible",
+          whereToWatch:
+            item.whereToWatch && item.whereToWatch.length > 0
+              ? item.whereToWatch
+              : ["No disponible"],
+          seasons: item.seasons,
+          source: "catalog",
         })
       }
       onRemoveFavorite={(item) => removeFavorite(item.key)}
+      onOpenDetails={(item) =>
+        navigation.navigate("Details", {
+          id: item.key,
+          title: item.title,
+          mediaType: item.mediaType || "movie",
+          imageSrc: item.imageSrc,
+          description: item.description,
+          cast: item.cast,
+          releaseDate: item.releaseDate,
+          whereToWatch: item.whereToWatch,
+          seasons: item.seasons,
+          source: "catalog",
+        })
+      }
     />
   );
 }

--- a/src/domain/entities/Favorite.ts
+++ b/src/domain/entities/Favorite.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { MovieSchema } from "./Movie";
+import { MovieSchema, SeasonSchema } from "./Movie";
 
 /**
  * Media type enum for favorites
@@ -21,6 +21,27 @@ export const PlatformEnum = z.enum([
 ]);
 export type Platform = z.infer<typeof PlatformEnum>;
 
+export const FavoriteSourceEnum = z.enum(["catalog", "manual"]);
+export type FavoriteSource = z.infer<typeof FavoriteSourceEnum>;
+
+const LEGACY_MANUAL_ID_REGEX = /^\d{12,}$/;
+
+function inferFavoriteSource(input: { id: string; platform?: Platform }): FavoriteSource {
+  if (input.id.startsWith("custom-")) {
+    return "manual";
+  }
+
+  if (input.platform) {
+    return "manual";
+  }
+
+  if (LEGACY_MANUAL_ID_REGEX.test(input.id)) {
+    return "manual";
+  }
+
+  return "catalog";
+}
+
 /**
  * Zod schema for Favorite entity
  * Represents a user's favorite movie or series with metadata
@@ -31,7 +52,51 @@ export const FavoriteSchema = z.object({
   mediaType: MediaTypeEnum, // NEW: required field
   url: z.string().optional(), // Optional per product decision
   platform: PlatformEnum.optional(), // Optional per product decision
+  description: z.string().optional(),
+  cast: z.array(z.string()).optional(),
+  releaseDate: z.string().optional(),
+  whereToWatch: z.array(z.string()).optional(),
+  seasons: z.array(SeasonSchema).optional(),
+  source: FavoriteSourceEnum.optional(),
   addedAt: z.string().datetime().optional(), // ISO 8601 datetime string
+});
+
+const RequiredFavoriteTextSchema = z.string().trim().min(1);
+const RequiredFavoriteArraySchema = z.array(RequiredFavoriteTextSchema).min(1);
+
+export const FavoriteWithDetailsSchema = FavoriteSchema.extend({
+  description: RequiredFavoriteTextSchema,
+  cast: RequiredFavoriteArraySchema,
+  releaseDate: RequiredFavoriteTextSchema,
+  whereToWatch: RequiredFavoriteArraySchema,
+  seasons: z.array(SeasonSchema).optional(),
+}).superRefine((favorite, ctx) => {
+  if (favorite.mediaType !== "series" || favorite.source !== "manual") {
+    return;
+  }
+
+  if (!favorite.seasons || favorite.seasons.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["seasons"],
+      message: "Series favorites must include at least one season.",
+    });
+    return;
+  }
+
+  const hasInvalidSeason = favorite.seasons.some(
+    (season) =>
+      season.episodes.length === 0 ||
+      season.episodes.some((episode) => !episode.releaseDate?.trim())
+  );
+
+  if (hasInvalidSeason) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["seasons"],
+      message: "Every series episode must include a release date.",
+    });
+  }
 });
 
 /**
@@ -75,12 +140,20 @@ export function validateFavorite(data: unknown): Favorite {
   return FavoriteSchema.parse(data);
 }
 
+export function validateFavoriteWithDetails(data: unknown): Favorite {
+  return FavoriteWithDetailsSchema.parse(data);
+}
+
 /**
  * Validates an array of favorites
  * Throws ZodError if validation fails
  */
 export function validateFavorites(data: unknown): Favorite[] {
   return FavoriteArraySchema.parse(data);
+}
+
+export function validateFavoritesWithDetails(data: unknown): Favorite[] {
+  return z.array(FavoriteWithDetailsSchema).parse(data);
 }
 
 /**
@@ -127,6 +200,14 @@ export function migrateLegacyFavorite(data: unknown): Favorite {
       const parsedPlatform = PlatformEnum.safeParse(parsed.platform);
       return parsedPlatform.success ? parsedPlatform.data : undefined;
     })(),
+    source: inferFavoriteSource({
+      id: parsed.id,
+      platform: (() => {
+        if (!parsed.platform) return undefined;
+        const parsedPlatform = PlatformEnum.safeParse(parsed.platform);
+        return parsedPlatform.success ? parsedPlatform.data : undefined;
+      })(),
+    }),
     addedAt,
   };
 }
@@ -144,7 +225,15 @@ export function validateAndMigrateFavorites(data: unknown): Favorite[] {
     // Try new schema first
     const newResult = FavoriteSchema.safeParse(item);
     if (newResult.success) {
-      return newResult.data;
+      return {
+        ...newResult.data,
+        source:
+          newResult.data.source ||
+          inferFavoriteSource({
+            id: newResult.data.id,
+            platform: newResult.data.platform,
+          }),
+      };
     }
 
     // Fall back to legacy migration
@@ -178,6 +267,7 @@ export function createFavorite(
     title: movie.primaryTitle, // Map primaryTitle → title
     mediaType: "movie", // Default to movie for TMDB movies
     url: movie.primaryImage?.url,
+    source: "catalog",
     ...overrides,
   });
 

--- a/src/domain/entities/ManualFavorite.ts
+++ b/src/domain/entities/ManualFavorite.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+import { SeasonSchema, type Season } from "@/domain/entities/Movie";
+
+const ManualEpisodeSchema = z
+  .object({
+    episodeNumber: z.number().int().positive(),
+    title: z.string().trim().min(1, "Episode title is required"),
+    releaseDate: z.string().trim().min(1, "Episode release date is required"),
+  })
+  .strict();
+
+const ManualSeasonSchema = z
+  .object({
+    seasonNumber: z.number().int().positive(),
+    title: z.string().trim().optional(),
+    episodes: z.array(ManualEpisodeSchema).min(1, "Season must include at least one episode"),
+  })
+  .strict();
+
+export const ManualSeriesSeasonsSchema = z.array(ManualSeasonSchema).min(1, "At least one season is required");
+
+export function parseManualSeriesSeasonsPayload(payload: string): Season[] {
+  const parsed: unknown = JSON.parse(payload);
+  return SeasonSchema.array().parse(ManualSeriesSeasonsSchema.parse(parsed));
+}

--- a/src/domain/entities/Movie.ts
+++ b/src/domain/entities/Movie.ts
@@ -1,5 +1,28 @@
 import { z } from "zod";
 
+export const EpisodeSchema = z.object({
+  episodeNumber: z.number(),
+  title: z.string(),
+  releaseDate: z.string().optional(),
+});
+
+export const SeasonSchema = z.object({
+  seasonNumber: z.number(),
+  title: z.string().optional(),
+  episodes: z.array(EpisodeSchema),
+});
+
+const RequiredTextSchema = z.string().trim().min(1);
+
+export const EpisodeDetailsSchema = EpisodeSchema.extend({
+  title: RequiredTextSchema,
+  releaseDate: RequiredTextSchema,
+});
+
+export const SeasonDetailsSchema = SeasonSchema.extend({
+  episodes: z.array(EpisodeDetailsSchema).min(1),
+});
+
 /**
  * Zod schema for Movie entity
  * Represents a movie from TMDB API with all relevant fields
@@ -31,6 +54,10 @@ export const MovieSchema = z.object({
   endYear: z.number().optional(),
   runtimeSeconds: z.number().optional(),
   plot: z.string().optional(),
+  cast: z.array(z.string()).optional(),
+  releaseDate: z.string().optional(),
+  whereToWatch: z.array(z.string()).optional(),
+  seasons: z.array(SeasonSchema).optional(),
   isAdult: z.boolean().optional(),
   originCountries: z
     .array(
@@ -56,11 +83,37 @@ export const MovieSchema = z.object({
     .optional(),
 });
 
+export const MovieDetailsSchema = MovieSchema.extend({
+  plot: RequiredTextSchema,
+  cast: z.array(RequiredTextSchema).min(1),
+  releaseDate: RequiredTextSchema,
+  whereToWatch: z.array(RequiredTextSchema).min(1),
+  seasons: z.array(SeasonDetailsSchema).optional(),
+}).superRefine((movie, ctx) => {
+  const normalizedType = movie.type.toLowerCase();
+  const isSeries = normalizedType.includes("tv") || normalizedType.includes("series");
+
+  if (!isSeries) {
+    return;
+  }
+
+  if (!movie.seasons || movie.seasons.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["seasons"],
+      message: "Series titles must include at least one season with episodes.",
+    });
+  }
+});
+
 /**
  * TypeScript type inferred from MovieSchema
  * Use this for type annotations throughout the app
  */
 export type Movie = z.infer<typeof MovieSchema>;
+export type MovieDetails = z.infer<typeof MovieDetailsSchema>;
+export type Episode = z.infer<typeof EpisodeSchema>;
+export type Season = z.infer<typeof SeasonSchema>;
 
 /**
  * Schema for validating an array of movies
@@ -109,6 +162,10 @@ export function toSearchResultItem(movie: Movie): MovieSearchResultItem {
  */
 export function validateMovie(data: unknown): Movie {
   return MovieSchema.parse(data);
+}
+
+export function validateMovieDetails(data: unknown): MovieDetails {
+  return MovieDetailsSchema.parse(data);
 }
 
 /**

--- a/src/domain/repositories/IMovieRepository.ts
+++ b/src/domain/repositories/IMovieRepository.ts
@@ -1,4 +1,4 @@
-import { Movie, MovieSearchResponse } from "@/domain/entities/Movie";
+import { MovieDetails, MovieSearchResponse } from "@/domain/entities/Movie";
 
 /**
  * Repository interface for Movie operations
@@ -25,5 +25,5 @@ export interface IMovieRepository {
    * @param id Movie ID
    * @returns Movie or null if not found
    */
-  getById(id: string): Promise<Movie | null>;
+  getById(id: string): Promise<MovieDetails | null>;
 }

--- a/src/repositories/APIMovieRepository.ts
+++ b/src/repositories/APIMovieRepository.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 import type { IMovieRepository } from "@/domain/repositories/IMovieRepository";
+import { movieTitles as movieTitlesSeed } from "@/constants/movieTitles";
 import {
+  MovieDetailsSchema,
   MovieSchema,
   MovieSearchResponseSchema,
 } from "@/domain/entities/Movie";
-import type { Movie, MovieSearchResponse } from "@/domain/entities/Movie";
+import type { Movie, MovieDetails, MovieSearchResponse } from "@/domain/entities/Movie";
 
 /**
  * Zod schemas for API validation
@@ -57,12 +59,249 @@ const APIResponseSchema = z.object({
   titles: z.array(APIMovieSchema),
 });
 
+const APIPrecisionDateSchema = z.object({
+  year: z.number().int().optional(),
+  month: z.number().int().optional(),
+  day: z.number().int().optional(),
+});
+
+const APINameSchema = z.object({
+  displayName: z.string(),
+});
+
+const APITitleDetailsSchema = APIMovieSchema.extend({
+  stars: z.array(APINameSchema).optional(),
+});
+
+const APIReleaseDatesResponseSchema = z.object({
+  releaseDates: z
+    .array(
+      z.object({
+        releaseDate: APIPrecisionDateSchema.optional(),
+        country: z
+          .object({
+            code: z.string(),
+            name: z.string(),
+          })
+          .optional(),
+      })
+    )
+    .optional(),
+  nextPageToken: z.string().optional(),
+});
+
+const APIEpisodeSchema = z.object({
+  season: z.string().optional(),
+  episodeNumber: z.number().int().optional(),
+  title: z.string().optional(),
+  releaseDate: APIPrecisionDateSchema.optional(),
+});
+
+const APIEpisodesResponseSchema = z.object({
+  episodes: z.array(APIEpisodeSchema).optional(),
+  nextPageToken: z.string().optional(),
+});
+
+type APIReleaseDateEntry = NonNullable<z.infer<typeof APIReleaseDatesResponseSchema>["releaseDates"]>[number];
+
+function formatPrecisionDate(date?: z.infer<typeof APIPrecisionDateSchema>): string | undefined {
+  if (!date?.year) {
+    return undefined;
+  }
+
+  if (!date.month) {
+    return String(date.year);
+  }
+
+  if (!date.day) {
+    return `${date.year}-${String(date.month).padStart(2, "0")}`;
+  }
+
+  return `${date.year}-${String(date.month).padStart(2, "0")}-${String(date.day).padStart(2, "0")}`;
+}
+
+function extractOptionalCast(rawData: unknown): string[] | undefined {
+  const castCandidate = (rawData as { cast?: unknown })?.cast;
+  const parsedCast = z.array(z.string()).safeParse(castCandidate);
+
+  if (parsedCast.success) {
+    const normalizedCast = parsedCast.data.map((name) => name.trim()).filter(Boolean);
+
+    if (normalizedCast.length > 0) {
+      return normalizedCast;
+    }
+  }
+
+  const starsCandidate = (rawData as { stars?: unknown })?.stars;
+  const parsedStars = z.array(APINameSchema).safeParse(starsCandidate);
+
+  if (!parsedStars.success) {
+    return undefined;
+  }
+
+  const normalizedStars = parsedStars.data
+    .map((star) => star.displayName.trim())
+    .filter(Boolean);
+
+  return normalizedStars.length > 0 ? normalizedStars : undefined;
+}
+
+function normalizeCast(title: z.infer<typeof APITitleDetailsSchema>): string[] | undefined {
+  const fromStars = title.stars?.map((star) => star.displayName.trim()).filter(Boolean);
+
+  if (fromStars && fromStars.length > 0) {
+    return fromStars;
+  }
+
+  return undefined;
+}
+
+function extractOptionalWhereToWatch(rawData: unknown): string[] | undefined {
+  const whereToWatchCandidate = (rawData as { whereToWatch?: unknown })?.whereToWatch;
+  const parsedWhereToWatch = z.array(z.string()).safeParse(whereToWatchCandidate);
+
+  if (!parsedWhereToWatch.success) {
+    return undefined;
+  }
+
+  const normalizedWhereToWatch = parsedWhereToWatch.data
+    .map((provider) => provider.trim())
+    .filter(Boolean);
+
+  return normalizedWhereToWatch.length > 0 ? normalizedWhereToWatch : undefined;
+}
+
+function isSeriesType(type: string): boolean {
+  const normalized = type.toLowerCase();
+  return normalized.includes("tv") || normalized.includes("series");
+}
+
+function normalizeImageType(type?: string):
+  | "POSTER"
+  | "STILL_FRAME"
+  | "EVENT"
+  | "BEHIND_THE_SCENES"
+  | "PUBLICITY"
+  | "PRODUCTION_ART"
+  | undefined {
+  if (!type) {
+    return undefined;
+  }
+
+  const normalized = type.toUpperCase();
+  const allowedTypes = new Set([
+    "POSTER",
+    "STILL_FRAME",
+    "EVENT",
+    "BEHIND_THE_SCENES",
+    "PUBLICITY",
+    "PRODUCTION_ART",
+  ]);
+
+  if (!allowedTypes.has(normalized)) {
+    return undefined;
+  }
+
+  return normalized as
+    | "POSTER"
+    | "STILL_FRAME"
+    | "EVENT"
+    | "BEHIND_THE_SCENES"
+    | "PUBLICITY"
+    | "PRODUCTION_ART";
+}
+
 /**
  * API implementation of IMovieRepository
  * Validates all responses with Zod schemas
  */
 export class APIMovieRepository implements IMovieRepository {
   private readonly baseUrl: string;
+
+  private async fetchOptional<T>(
+    path: string,
+    schema: z.ZodType<T>
+  ): Promise<T | undefined> {
+    try {
+      const url = new URL(`${this.baseUrl}${path}`);
+      const res = await fetch(url);
+
+      if (!res.ok) {
+        return undefined;
+      }
+
+      const data: unknown = await res.json();
+      const parsed = schema.safeParse(data);
+
+      if (!parsed.success) {
+        return undefined;
+      }
+
+      return parsed.data;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async fetchAllReleaseDates(
+    id: string
+  ): Promise<APIReleaseDateEntry[]> {
+    const releaseDates: APIReleaseDateEntry[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const query = pageToken
+        ? `?pageToken=${encodeURIComponent(pageToken)}`
+        : "";
+
+      const page = await this.fetchOptional(
+        `/titles/${id}/releaseDates${query}`,
+        APIReleaseDatesResponseSchema
+      );
+
+      if (!page) {
+        break;
+      }
+
+      page.releaseDates?.forEach((entry) => {
+        releaseDates.push(entry);
+      });
+
+      pageToken = page.nextPageToken;
+    } while (pageToken);
+
+    return releaseDates;
+  }
+
+  private async fetchAllEpisodes(
+    id: string
+  ): Promise<z.infer<typeof APIEpisodeSchema>[]> {
+    const episodes: z.infer<typeof APIEpisodeSchema>[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const query = pageToken
+        ? `?pageToken=${encodeURIComponent(pageToken)}`
+        : "";
+
+      const page = await this.fetchOptional(
+        `/titles/${id}/episodes${query}`,
+        APIEpisodesResponseSchema
+      );
+
+      if (!page) {
+        break;
+      }
+
+      if (page.episodes) {
+        episodes.push(...page.episodes);
+      }
+
+      pageToken = page.nextPageToken;
+    } while (pageToken);
+
+    return episodes;
+  }
 
   constructor() {
     this.baseUrl = process.env.EXPO_PUBLIC_API_URL || "";
@@ -86,7 +325,7 @@ export class APIMovieRepository implements IMovieRepository {
       throw new Error(`HTTP error! status: ${res.status}`);
     }
 
-    const data = await res.json();
+    const data: unknown = await res.json();
 
     // Validate raw API response
     const parsed = APIResponseSchema.safeParse(data);
@@ -109,14 +348,11 @@ export class APIMovieRepository implements IMovieRepository {
   }
 
   async getRandom(): Promise<MovieSearchResponse> {
-    let movieTitles: string[] = [];
-
-    try {
-      const { movieTitles: titles } = require("@/constants/movieTitles");
-      movieTitles = titles.trim().split(",");
-    } catch {
-      throw new Error("Failed to load movie titles for random selection");
-    }
+    const movieTitles = movieTitlesSeed
+      .trim()
+      .split(",")
+      .map((title) => title.trim())
+      .filter(Boolean);
 
     if (movieTitles.length === 0) {
       throw new Error("No movie titles available");
@@ -128,7 +364,7 @@ export class APIMovieRepository implements IMovieRepository {
     return this.search(randomMovie);
   }
 
-  async getById(id: string): Promise<Movie | null> {
+  async getById(id: string): Promise<MovieDetails | null> {
     if (!this.baseUrl) {
       throw new Error("API URL not configured");
     }
@@ -144,10 +380,99 @@ export class APIMovieRepository implements IMovieRepository {
       throw new Error(`HTTP error! status: ${res.status}`);
     }
 
-    const data = await res.json();
+    const data: unknown = await res.json();
 
-    // Validate with Zod
-    const parsed = MovieSchema.safeParse(data);
+    const parsedTitle = APITitleDetailsSchema.safeParse(data);
+
+    if (!parsedTitle.success) {
+      console.error("Movie validation failed:", parsedTitle.error);
+      throw new Error("Invalid movie data from API");
+    }
+
+    const title = parsedTitle.data;
+    const isSeries = isSeriesType(title.type);
+
+    const [releaseDates, episodesList] = await Promise.all([
+      this.fetchAllReleaseDates(id),
+      isSeries ? this.fetchAllEpisodes(id) : Promise.resolve([]),
+    ]);
+
+    const releaseDateFromList = releaseDates
+      .map((value) => formatPrecisionDate(value.releaseDate))
+      .find(Boolean);
+
+    const whereToWatch = extractOptionalWhereToWatch(data) || ["No disponible"];
+
+    const releaseDate = releaseDateFromList || title.startYear?.toString() || "No disponible";
+
+    const seasonsByNumber = new Map<
+      number,
+      { seasonNumber: number; episodes: { episodeNumber: number; title: string; releaseDate: string }[] }
+    >();
+
+    episodesList.forEach((episode, index) => {
+      const seasonNumber = Number.parseInt(episode.season ?? "", 10);
+
+      if (!Number.isFinite(seasonNumber)) {
+        return;
+      }
+
+      const normalizedReleaseDate = formatPrecisionDate(episode.releaseDate);
+
+      if (!normalizedReleaseDate) {
+        return;
+      }
+
+      const existingSeason = seasonsByNumber.get(seasonNumber) || {
+        seasonNumber,
+        episodes: [],
+      };
+
+      existingSeason.episodes.push({
+        episodeNumber: episode.episodeNumber ?? index + 1,
+        title: episode.title || `Episodio ${episode.episodeNumber ?? index + 1}`,
+        releaseDate: normalizedReleaseDate,
+      });
+
+      seasonsByNumber.set(seasonNumber, existingSeason);
+    });
+
+    const mappedSeasons =
+      seasonsByNumber.size > 0
+        ? Array.from(seasonsByNumber.values()).sort(
+            (a, b) => a.seasonNumber - b.seasonNumber
+          )
+        : undefined;
+
+    const moviePayload: MovieDetails = {
+      id: title.id,
+      type: title.type,
+      primaryTitle: title.primaryTitle,
+      originalTitle: title.originalTitle || title.primaryTitle,
+      primaryImage: title.primaryImage
+        ? {
+            url: title.primaryImage.url,
+            width: title.primaryImage.width,
+            height: title.primaryImage.height,
+            type: normalizeImageType(title.primaryImage.type),
+          }
+        : undefined,
+      genres: title.genres,
+      startYear: title.startYear,
+      endYear: title.endYear,
+      runtimeSeconds: title.runtimeSeconds,
+      plot: title.plot || "No disponible",
+      cast: normalizeCast(title) || extractOptionalCast(data) || ["No disponible"],
+      releaseDate,
+      whereToWatch,
+      seasons: mappedSeasons,
+      isAdult: title.isAdult,
+      originCountries: title.originCountries,
+      spokenLanguages: title.spokenLanguages,
+      rating: title.rating,
+    };
+
+    const parsed = MovieDetailsSchema.safeParse(moviePayload);
 
     if (!parsed.success) {
       console.error("Movie validation failed:", parsed.error);

--- a/src/repositories/AsyncStorageFavoriteRepository.ts
+++ b/src/repositories/AsyncStorageFavoriteRepository.ts
@@ -51,7 +51,7 @@ export class AsyncStorageFavoriteRepository implements IFavoriteRepository {
         return;
       }
 
-      const parsed = JSON.parse(storage);
+      const parsed: unknown = JSON.parse(storage);
 
       if (!Array.isArray(parsed) || parsed.length === 0) {
         await AsyncStorage.setItem(MIGRATION_FLAG, "true");
@@ -79,7 +79,7 @@ export class AsyncStorageFavoriteRepository implements IFavoriteRepository {
     }
 
     try {
-      const parsed = JSON.parse(storage);
+      const parsed: unknown = JSON.parse(storage);
 
       // Validate and migrate data (handles old formats)
       if (Array.isArray(parsed)) {
@@ -206,7 +206,7 @@ export class AsyncStorageFavoriteRepository implements IFavoriteRepository {
    */
   async importFromJSON(json: string): Promise<Favorite[]> {
     try {
-      const parsed = JSON.parse(json);
+      const parsed: unknown = JSON.parse(json);
 
       if (!Array.isArray(parsed)) {
         throw new Error("Invalid import format: expected array");

--- a/src/repositories/__mocks__/MockMovieRepository.ts
+++ b/src/repositories/__mocks__/MockMovieRepository.ts
@@ -1,18 +1,18 @@
 import type { IMovieRepository } from "@/domain/repositories/IMovieRepository";
-import type { Movie, MovieSearchResponse } from "@/domain/entities/Movie";
+import type { MovieDetails, MovieSearchResponse } from "@/domain/entities/Movie";
 
 /**
  * Mock implementation of IMovieRepository for testing
  */
 export class MockMovieRepository implements IMovieRepository {
   private mockData: MovieSearchResponse = { titles: [] };
-  private movieById: Map<string, Movie> = new Map();
+  private movieById: Map<string, MovieDetails> = new Map();
 
   setMockData(data: MovieSearchResponse): void {
     this.mockData = data;
   }
 
-  setMockMovie(movie: Movie): void {
+  setMockMovie(movie: MovieDetails): void {
     this.movieById.set(movie.id, movie);
   }
 
@@ -24,7 +24,7 @@ export class MockMovieRepository implements IMovieRepository {
     return this.mockData;
   }
 
-  async getById(id: string): Promise<Movie | null> {
+  async getById(id: string): Promise<MovieDetails | null> {
     return this.movieById.get(id) || null;
   }
 


### PR DESCRIPTION
## Summary
- Move app shell from bottom tabs to a stack shell with global floating add CTA and modal form flow.
- Add dedicated Details route/container with normalized payload parsing and resilient back CTA fallback for direct-entry and reload paths.
- Harden favorites/details domain and repository handling for richer details metadata and manual series payload validation.

Closes #12
Closes #13
Closes #15
Closes #18
Closes #19