### PR TITLE
ci(workflow): switch deploy pipeline from npm to pnpm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "18"
-          cache: "npm"
+          cache: "pnpm"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build Expo web app
         run: npx expo export -p web

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vibevault",
   "main": "App.tsx",
   "version": "1.0.0",
+  "packageManager": "pnpm@9.15.9",
   "homepage": "https://goi17.github.io/VibeVault",
   "scripts": {
     "start": "node ./scripts/start-clean.js",


### PR DESCRIPTION
## Summary
- Update GitHub Pages deploy workflow to use pnpm cache and pnpm install.
- Add pnpm setup action before dependency install in CI.
- Declare packageManager in package.json for consistent tooling expectations.

Closes #33