### PR TITLE
docs(env): make API URL the only required setup variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 EXPO_PUBLIC_API_URL="https://api.imdbapi.dev"
-EXPO_PUBLIC_GOOGLE_CLIENT_ID="your-google-web-client-id.apps.googleusercontent.com"
-EXPO_PUBLIC_ANDROID_CLIENT_ID="your-google-android-client-id.apps.googleusercontent.com"
-EXPO_PUBLIC_IOS_CLIENT_ID="your-google-ios-client-id.apps.googleusercontent.com"
+
+# Optional (Google auth / backup flows only):
+# EXPO_PUBLIC_GOOGLE_CLIENT_ID="your-google-web-client-id.apps.googleusercontent.com"
+# EXPO_PUBLIC_ANDROID_CLIENT_ID="your-google-android-client-id.apps.googleusercontent.com"
+# EXPO_PUBLIC_IOS_CLIENT_ID="your-google-ios-client-id.apps.googleusercontent.com"

--- a/README.md
+++ b/README.md
@@ -63,9 +63,12 @@ Use `.env.example` as the template:
 cp .env.example .env
 ```
 
-Populate values for:
+Populate required value:
 
 - `EXPO_PUBLIC_API_URL`
+
+Optional (only if using Google auth / backup flows):
+
 - `EXPO_PUBLIC_GOOGLE_CLIENT_ID`
 - `EXPO_PUBLIC_ANDROID_CLIENT_ID`
 - `EXPO_PUBLIC_IOS_CLIENT_ID`


### PR DESCRIPTION
## Summary
- Keep EXPO_PUBLIC_API_URL as the only required variable for default app setup.
- Mark Google OAuth env vars as optional for Google auth/backup flows.
- Update env template and README onboarding section for clearer setup.

Closes #37