### PR TITLE
ci(workflow): wire API_URL variable into Expo web build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Build Expo web app
         run: npx expo export -p web
         env:
+          EXPO_PUBLIC_API_URL: ${{ vars.API_URL }}
           EXPO_PUBLIC_URL: /VibeVault
 
       - name: Fix asset paths


### PR DESCRIPTION
## Summary
- Inject repository variable `API_URL` into deploy build as `EXPO_PUBLIC_API_URL`.
- Keep GitHub Pages base-path env as-is.
- Ensure API base URL is available during Expo web export in CI.

Closes #39