### PR TITLE
fix(search): render search input in results header

### DIFF
--- a/app/home/search/query.tsx
+++ b/app/home/search/query.tsx
@@ -1,12 +1,50 @@
-import { useRoute, type RouteProp } from "@react-navigation/native";
-import { type ReactElement } from "react";
+import {
+  useNavigation,
+  useRoute,
+  type NavigationProp,
+  type RouteProp,
+} from "@react-navigation/native";
+import { useCallback, useEffect, useLayoutEffect, useState, type ReactElement } from "react";
 
 import type { RootStackParamList } from "@/app/navigation/types";
+import { SearchHeaderInput } from "@/components/navigation/SearchHeaderInput";
 import { SearchContainer } from "@/containers/SearchContainer";
 
 export default function SearchScreen(): ReactElement {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const route = useRoute<RouteProp<RootStackParamList, "Search">>();
   const query = route.params?.query ?? "";
+  const [searchDraft, setSearchDraft] = useState(query);
+
+  useEffect(() => {
+    setSearchDraft(query);
+  }, [query]);
+
+  const handleSubmitSearch = useCallback((): void => {
+    const nextQuery = searchDraft.trim();
+    if (!nextQuery || nextQuery === query) {
+      return;
+    }
+
+    navigation.setParams({ query: nextQuery });
+  }, [navigation, query, searchDraft]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: () => (
+        <SearchHeaderInput
+          value={searchDraft}
+          onChangeText={setSearchDraft}
+          onSubmit={handleSubmitSearch}
+        />
+      ),
+      headerTitleAlign: "center",
+      headerTitleContainerStyle: {
+        left: 70,
+        right: 16,
+      },
+    });
+  }, [handleSubmitSearch, navigation, searchDraft]);
 
   return <SearchContainer query={query} />;
 }

--- a/components/navigation/SearchHeaderInput.tsx
+++ b/components/navigation/SearchHeaderInput.tsx
@@ -1,0 +1,46 @@
+import { type ReactElement } from "react";
+import { Text, TextInput, TouchableOpacity, View } from "react-native";
+
+import { Colors } from "@/constants/Colors";
+
+interface SearchHeaderInputProps {
+  value: string;
+  onChangeText: (value: string) => void;
+  onSubmit: () => void;
+}
+
+const palette = Colors.light;
+
+export function SearchHeaderInput({ value, onChangeText, onSubmit }: SearchHeaderInputProps): ReactElement {
+  return (
+    <View
+      style={{
+        minHeight: 40,
+        borderRadius: 14,
+        borderWidth: 1,
+        borderColor: palette.shellBorder,
+        backgroundColor: palette.shellSurface,
+        flexDirection: "row",
+        alignItems: "center",
+        paddingHorizontal: 10,
+        gap: 8,
+        width: "100%",
+      }}
+    >
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        style={{ flex: 1, color: palette.text, fontSize: 15 }}
+        placeholder="Search titles"
+        placeholderTextColor={palette.shellMutedText}
+        autoCapitalize="none"
+        autoCorrect={false}
+        returnKeyType="search"
+        onSubmitEditing={onSubmit}
+      />
+      <TouchableOpacity onPress={onSubmit} accessibilityRole="button" accessibilityLabel="Submit search">
+        <Text style={{ color: palette.shellMutedText, fontWeight: "600" }}>Search</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/components/views/SearchView.tsx
+++ b/components/views/SearchView.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, type ReactElement } from "react";
-import { View, Text, TextInput, TouchableOpacity } from "react-native";
+import { type ReactElement } from "react";
+import { View, Text } from "react-native";
 
 import MasonryList, { type MasonryItemData } from "@/components/Masonry";
 import { Colors } from "@/constants/Colors";
@@ -10,7 +10,6 @@ interface SearchViewProps {
   errorMessage?: string;
   data: MasonryItemData[];
   favoriteIds: ReadonlySet<string>;
-  onSearchQuery: (query: string) => void;
   onAddFavorite: (item: MasonryItemData) => void;
   onRemoveFavorite: (item: MasonryItemData) => void;
   onOpenDetails: (item: MasonryItemData) => void;
@@ -24,64 +23,13 @@ export function SearchView({
   errorMessage,
   data,
   favoriteIds,
-  onSearchQuery,
   onAddFavorite,
   onRemoveFavorite,
   onOpenDetails,
 }: SearchViewProps): ReactElement {
-  const [searchDraft, setSearchDraft] = useState(query);
-
-  useEffect(() => {
-    setSearchDraft(query);
-  }, [query]);
-
-  const submitSearch = (): void => {
-    const nextQuery = searchDraft.trim();
-    if (!nextQuery || nextQuery === query) {
-      return;
-    }
-
-    onSearchQuery(nextQuery);
-  };
-
   if (isLoading) {
     return (
       <View style={{ backgroundColor: palette.shellBackground, flex: 1 }}>
-        <View
-          style={{
-            marginHorizontal: 16,
-            marginTop: 14,
-            marginBottom: 6,
-            minHeight: 44,
-            borderRadius: 14,
-            borderWidth: 1,
-            borderColor: palette.shellBorder,
-            backgroundColor: palette.shellSurface,
-            flexDirection: "row",
-            alignItems: "center",
-            paddingHorizontal: 10,
-            gap: 8,
-          }}
-        >
-          <TextInput
-            value={searchDraft}
-            onChangeText={setSearchDraft}
-            style={{ flex: 1, color: palette.text, fontSize: 15 }}
-            placeholder="Search titles"
-            placeholderTextColor={palette.shellMutedText}
-            autoCapitalize="none"
-            autoCorrect={false}
-            returnKeyType="search"
-            onSubmitEditing={submitSearch}
-          />
-          <TouchableOpacity
-            onPress={submitSearch}
-            accessibilityRole="button"
-            accessibilityLabel="Submit search"
-          >
-            <Text style={{ color: palette.shellMutedText, fontWeight: "600" }}>Search</Text>
-          </TouchableOpacity>
-        </View>
         <View style={{ flex: 1, justifyContent: "center", alignItems: "center", padding: 20 }}>
           <Text style={{ color: palette.text, fontSize: 18 }}>Searching for &quot;{query}&quot;...</Text>
         </View>
@@ -92,41 +40,6 @@ export function SearchView({
   if (errorMessage) {
     return (
       <View style={{ backgroundColor: palette.shellBackground, flex: 1 }}>
-        <View
-          style={{
-            marginHorizontal: 16,
-            marginTop: 14,
-            marginBottom: 6,
-            minHeight: 44,
-            borderRadius: 14,
-            borderWidth: 1,
-            borderColor: palette.shellBorder,
-            backgroundColor: palette.shellSurface,
-            flexDirection: "row",
-            alignItems: "center",
-            paddingHorizontal: 10,
-            gap: 8,
-          }}
-        >
-          <TextInput
-            value={searchDraft}
-            onChangeText={setSearchDraft}
-            style={{ flex: 1, color: palette.text, fontSize: 15 }}
-            placeholder="Search titles"
-            placeholderTextColor={palette.shellMutedText}
-            autoCapitalize="none"
-            autoCorrect={false}
-            returnKeyType="search"
-            onSubmitEditing={submitSearch}
-          />
-          <TouchableOpacity
-            onPress={submitSearch}
-            accessibilityRole="button"
-            accessibilityLabel="Submit search"
-          >
-            <Text style={{ color: palette.shellMutedText, fontWeight: "600" }}>Search</Text>
-          </TouchableOpacity>
-        </View>
         <View style={{ flex: 1, justifyContent: "center", alignItems: "center", padding: 20 }}>
           <Text style={{ color: palette.text, fontSize: 18 }}>Error searching for &quot;{query}&quot;</Text>
           <Text style={{ color: palette.shellMutedText, fontSize: 14, marginTop: 10 }}>{errorMessage}</Text>
@@ -137,41 +50,6 @@ export function SearchView({
 
   return (
     <View style={{ backgroundColor: palette.shellBackground, flex: 1 }}>
-      <View
-        style={{
-          marginHorizontal: 16,
-          marginTop: 14,
-          marginBottom: 6,
-          minHeight: 44,
-          borderRadius: 14,
-          borderWidth: 1,
-          borderColor: palette.shellBorder,
-          backgroundColor: palette.shellSurface,
-          flexDirection: "row",
-          alignItems: "center",
-          paddingHorizontal: 10,
-          gap: 8,
-        }}
-      >
-        <TextInput
-          value={searchDraft}
-          onChangeText={setSearchDraft}
-          style={{ flex: 1, color: palette.text, fontSize: 15 }}
-          placeholder="Search titles"
-          placeholderTextColor={palette.shellMutedText}
-          autoCapitalize="none"
-          autoCorrect={false}
-          returnKeyType="search"
-          onSubmitEditing={submitSearch}
-        />
-        <TouchableOpacity
-          onPress={submitSearch}
-          accessibilityRole="button"
-          accessibilityLabel="Submit search"
-        >
-          <Text style={{ color: palette.shellMutedText, fontWeight: "600" }}>Search</Text>
-        </TouchableOpacity>
-      </View>
       <MasonryList
         data={data}
         isFavorites={false}

--- a/containers/SearchContainer.tsx
+++ b/containers/SearchContainer.tsx
@@ -53,7 +53,6 @@ export function SearchContainer({ query }: SearchContainerProps): ReactElement {
       errorMessage={error?.message}
       data={mappedData}
       favoriteIds={favoriteIds}
-      onSearchQuery={setActiveQuery}
       onAddFavorite={(item) =>
         addFavorite({
           id: item.key,


### PR DESCRIPTION
Closes #45

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Move the Search Results query input from the body into the stack header.
- Preserve query behavior (draft typing, trim-on-submit, ignore empty/same query, route param sync).
- Keep SearchView focused on results/loading/error rendering only.

## Changes
| File | Change |
|------|--------|
| `app/home/search/query.tsx` | Added header input wiring with `navigation.setOptions`, draft state, and submit handling. |
| `components/navigation/SearchHeaderInput.tsx` | New reusable typed header input component for Search screen. |
| `components/views/SearchView.tsx` | Removed in-body input UI and submit logic from loading/error/default states. |
| `containers/SearchContainer.tsx` | Removed obsolete `onSearchQuery` prop pass-through. |

## Validation
- [x] `./node_modules/.bin/eslint app/home/search/query.tsx containers/SearchContainer.tsx components/views/SearchView.tsx components/navigation/SearchHeaderInput.tsx`
- [x] `./node_modules/.bin/tsc --noEmit` *(fails on pre-existing baseline errors unrelated to this PR in `components/ParallaxScrollView.tsx`, `components/views/FavoritesView.tsx`, and `hooks/useThemeColor.ts`)*

## Checklist
- [x] Linked approved issue
- [ ] Added exactly one `type:*` label
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers