### PR TITLE
fix(header): keep back CTA consistent on favorites, details, and results

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,16 +7,16 @@ import type { LinkingOptions } from "@react-navigation/native";
 import { useMemo, type ReactElement } from "react";
 
 import { createStackNavigator } from "@react-navigation/stack";
+import type { StackNavigationProp } from "@react-navigation/stack";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { HeaderBackButton } from "@react-navigation/elements";
 import { useFonts } from "expo-font";
-import { Image } from "expo-image";
 import { View, Text } from "react-native";
 import Toast from "react-native-toast-message";
 import type { ToastConfig } from "react-native-toast-message";
 import "react-native-reanimated";
 
 import Header from "@/components/Header";
+import { LeftHeaderContent } from "@/components/common/LeftHeaderContent";
 import { client } from "@/constants/RQClient";
 import { SeasonSchema } from "@/domain/entities/Movie";
 import { RepositoryProvider } from "@/providers/RepositoryProvider";
@@ -88,6 +88,17 @@ function ThemedToast(): ReactElement {
 }
 
 const Stack = createStackNavigator<RootStackParamList>();
+
+function handleBackPress(navigation: StackNavigationProp<RootStackParamList>): () => void {
+  return () => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+
+    navigation.replace("Tabs", { screen: "Home" });
+  };
+}
 
 const linking: LinkingOptions<RootStackParamList> = {
   prefixes: ['http://localhost:8081', 'exp://localhost:8081'],
@@ -181,27 +192,20 @@ function RootNavigator(): ReactElement {
           <Stack.Screen
             name="Search"
             component={SearchScreen}
-            options={{
+            options={({ navigation }) => ({
               title: "Search",
               headerStyle: { backgroundColor: palette.shellBackground },
               headerTintColor: palette.text,
-              headerLeft: (props) => (
-                <View
-                  style={{
-                    flexDirection: "row",
-                    alignItems: "center",
-                    padding: 10,
-                    backgroundColor: palette.shellBackground,
-                  }}
-                >
-                  <HeaderBackButton {...props} tintColor={palette.text} />
-                  <Image
-                    style={{ width: 50, height: 30, resizeMode: "contain" }}
-                    source={require("../assets/images/logo.png")}
-                  />
-                </View>
+              headerLeft: () => (
+                <LeftHeaderContent
+                  showBackButton
+                  onBackPress={handleBackPress(navigation)}
+                  tintColor={palette.text}
+                  showLogo
+                  backgroundColor={palette.shellBackground}
+                />
               ),
-            }}
+            })}
           />
           <Stack.Screen
             name="Details"
@@ -210,32 +214,14 @@ function RootNavigator(): ReactElement {
               title: "Details",
               headerStyle: { backgroundColor: palette.shellBackground },
               headerTintColor: palette.text,
-              headerLeft: (props) => (
-                <View
-                  style={{
-                    flexDirection: "row",
-                    alignItems: "center",
-                    padding: 10,
-                    backgroundColor: palette.shellBackground,
-                  }}
-                >
-                  <HeaderBackButton
-                    {...props}
-                    tintColor={palette.text}
-                    onPress={() => {
-                      if (navigation.canGoBack()) {
-                        navigation.goBack();
-                        return;
-                      }
-
-                      navigation.replace("Tabs", { screen: "Home" });
-                    }}
-                  />
-                  <Image
-                    style={{ width: 50, height: 30, resizeMode: "contain" }}
-                    source={require("../assets/images/logo.png")}
-                  />
-                </View>
+              headerLeft: () => (
+                <LeftHeaderContent
+                  showBackButton
+                  onBackPress={handleBackPress(navigation)}
+                  tintColor={palette.text}
+                  showLogo
+                  backgroundColor={palette.shellBackground}
+                />
               ),
             })}
           />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigation, type NavigationProp } from "@react-navigation/native";
+import { useNavigation, useNavigationState, type NavigationProp } from "@react-navigation/native";
 import {
   Modal,
   Pressable,
@@ -13,9 +13,38 @@ import {
 } from "react-native";
 import Toast from "react-native-toast-message";
 import { IconSymbol } from "@/components/ui/IconSymbol";
+import { LeftHeaderContent } from "@/components/common/LeftHeaderContent";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { RootStackParamList } from "@/app/navigation/types";
 import { useThemePreference } from "@/providers/ThemePreferenceProvider";
+
+interface NavigationStateNode {
+  index: number;
+  routes: NavigationRouteNode[];
+}
+
+interface NavigationRouteNode {
+  name?: string;
+  state?: unknown;
+}
+
+function isNavigationStateNode(value: unknown): value is NavigationStateNode {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as { index?: unknown; routes?: unknown };
+  return typeof candidate.index === "number" && Array.isArray(candidate.routes);
+}
+
+function getActiveRouteName(state: unknown): string | null {
+  if (!isNavigationStateNode(state)) {
+    return null;
+  }
+
+  const activeRoute = state.routes[state.index];
+  return typeof activeRoute?.name === "string" ? activeRoute.name : null;
+}
 
 export default function Header(): React.ReactElement {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
@@ -27,6 +56,14 @@ export default function Header(): React.ReactElement {
   const { theme: activeTheme, palette, toggleTheme } = useThemePreference();
   const isCompact = width < 390;
   const toggleLabel = activeTheme === "light" ? "Toggle dark mode" : "Toggle light mode";
+  const isFavoritesRoute = useNavigationState((state) => {
+    const activeRootRoute = state.routes[state.index];
+    if (activeRootRoute?.name !== "Tabs") {
+      return false;
+    }
+
+    return getActiveRouteName(activeRootRoute.state) === "Favorites";
+  });
 
   const submitSearch = React.useCallback(() => {
     const query = searchQuery.trim();
@@ -68,6 +105,15 @@ export default function Header(): React.ReactElement {
     closeMenu();
   }, [closeMenu, toggleTheme]);
 
+  const handleBackPress = React.useCallback(() => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+
+    navigation.navigate("Tabs", { screen: "Home" });
+  }, [navigation]);
+
   const renderSearchBar = () => (
     <View
       style={[
@@ -78,20 +124,24 @@ export default function Header(): React.ReactElement {
         },
       ]}
     >
-      <TouchableOpacity
-        onPress={searchQuery ? clearSearch : undefined}
-        style={styles.leadingAction}
-        accessibilityRole={searchQuery ? "button" : undefined}
-        accessibilityLabel={searchQuery ? "Clear search" : "Search"}
-        hitSlop={8}
-        disabled={!searchQuery}
-      >
-        <IconSymbol
-          name={searchQuery ? "xmark.circle.fill" : "magnifyingglass"}
-          color={palette.shellMutedText}
-          size={16}
-        />
-      </TouchableOpacity>
+      {isFavoritesRoute ? (
+        <LeftHeaderContent showBackButton onBackPress={handleBackPress} tintColor={palette.shellMutedText} compact />
+      ) : (
+        <TouchableOpacity
+          onPress={searchQuery ? clearSearch : undefined}
+          style={styles.leadingAction}
+          accessibilityRole={searchQuery ? "button" : undefined}
+          accessibilityLabel={searchQuery ? "Clear search" : "Search"}
+          hitSlop={8}
+          disabled={!searchQuery}
+        >
+          <IconSymbol
+            name={searchQuery ? "xmark.circle.fill" : "magnifyingglass"}
+            color={palette.shellMutedText}
+            size={16}
+          />
+        </TouchableOpacity>
+      )}
       <TextInput
         ref={inputRef}
         style={[styles.searchInput, { color: palette.text }]}

--- a/components/common/LeftHeaderContent.tsx
+++ b/components/common/LeftHeaderContent.tsx
@@ -1,0 +1,57 @@
+import { type ReactElement } from "react";
+import { HeaderBackButton } from "@react-navigation/elements";
+import { Image } from "expo-image";
+import { StyleSheet, View, type ViewStyle } from "react-native";
+
+interface LeftHeaderContentProps {
+  showBackButton: boolean;
+  onBackPress: () => void;
+  tintColor: string;
+  showLogo?: boolean;
+  backgroundColor?: string;
+  compact?: boolean;
+}
+
+export function LeftHeaderContent({
+  showBackButton,
+  onBackPress,
+  tintColor,
+  showLogo = false,
+  backgroundColor,
+  compact = false,
+}: LeftHeaderContentProps): ReactElement {
+  const containerStyle: ViewStyle | undefined = backgroundColor ? { backgroundColor } : undefined;
+
+  return (
+    <View style={[styles.container, compact ? styles.compactContainer : undefined, containerStyle]}>
+      {showBackButton ? (
+        <HeaderBackButton tintColor={tintColor} onPress={onBackPress} accessibilityLabel="Go back" />
+      ) : null}
+      {showLogo ? (
+        <Image
+          style={styles.logo}
+          source={require("@/assets/images/logo.png")}
+          accessibilityLabel="VibeVault logo"
+        />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  compactContainer: {
+    paddingHorizontal: 0,
+    paddingVertical: 0,
+  },
+  logo: {
+    width: 50,
+    height: 30,
+    resizeMode: "contain",
+  },
+});


### PR DESCRIPTION
## Linked Issue
Closes #49

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Unifies left header rendering for Search and Details using a shared `LeftHeaderContent` component.
- Adds route-aware Back CTA on Favorites in the custom header so Favorites/Details/Results behave consistently.
- Centralizes back navigation fallback logic to go back when possible, or return to Home when history is unavailable.

## Changes
| File | Change |
|------|--------|
| `components/common/LeftHeaderContent.tsx` | Added reusable left-header component for Back CTA + optional logo. |
| `app/_layout.tsx` | Replaced inline `headerLeft` implementations for Search/Details with shared component and shared back handler. |
| `components/Header.tsx` | Added Favorites route detection and left Back CTA rendering inside the search header shell. |

## Validation
- [x] `./node_modules/.bin/eslint app/_layout.tsx components/Header.tsx components/common/LeftHeaderContent.tsx`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] Manually verified header/back behavior on Favorites, Details, and Results

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No `Co-Authored-By` trailers