### PR TITLE
docs: add agent-friendly project guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@
 - If failed, list only concrete file/line rule violations.
 - Do not run shell commands or external tools during review; review staged code statically.
 
+## Project Guardrails
+- Start with `docs/agent-guide.md` after reading this file to choose task-specific project context.
+- Keep `README.md` human-facing; put long-lived project knowledge in scoped `docs/` files.
+
 ## TypeScript
 - Use explicit types for public interfaces and exported functions.
 - Avoid `any`; prefer specific types or `unknown` with narrowing.

--- a/README.md
+++ b/README.md
@@ -1,139 +1,53 @@
 # VibeVault 🎬
 
-VibeVault is a React Native + Expo app for discovering titles, managing favorites, and viewing detailed movie/series metadata on mobile and web.
+VibeVault is a React Native + Expo app for discovering movies and series, managing favorites, and viewing detailed title metadata on mobile and web.
+
+## Quick start
+
+```bash
+git clone https://github.com/GOI17/VibeVault.git
+cd VibeVault
+pnpm install
+cp .env.example .env
+pnpm start
+```
+
+Populate `EXPO_PUBLIC_API_URL` in `.env` before running the app.
 
 ## What the app does
 
 - Browse a curated home feed.
 - Search titles from the header flow.
-- Open a dedicated **Details** screen (title, synopsis, cast, release date, where-to-watch, and seasons/episodes for series).
-- Add/remove favorites with double press.
-- Create manual favorites and filter favorites by media type.
-- Backup and restore favorites through the configured backup repository.
+- Open detailed movie/series metadata.
+- Add, remove, create, filter, back up, and restore favorites.
 
-## Tech stack (current)
+## Documentation
 
-- Expo SDK 55
-- React Native 0.83 + React 19
-- React Navigation (Stack + Bottom Tabs)
-- TanStack Query for server/cache state
-- AsyncStorage for local favorites persistence
-- Zod/Formik for input validation
+| Need | Read |
+|---|---|
+| Product capabilities and vocabulary | [`docs/project-overview.md`](docs/project-overview.md) |
+| Architecture, boundaries, and repo structure | [`docs/architecture.md`](docs/architecture.md) |
+| Local setup, environment, and scripts | [`docs/development.md`](docs/development.md) |
+| Validation and review checks | [`docs/verification.md`](docs/verification.md) |
+| GitHub Pages deployment | [`docs/deployment.md`](docs/deployment.md) |
+| Web zoom and browser policy | [`docs/web-platform-policy.md`](docs/web-platform-policy.md) |
+| Browser workflow and visual evidence | [`docs/browser-workflow.md`](docs/browser-workflow.md) |
+| GitHub issue and PR workflow | [`docs/github-workflow.md`](docs/github-workflow.md) |
+| Agent-specific guardrails | [`AGENTS.md`](AGENTS.md) and [`docs/agent-guide.md`](docs/agent-guide.md) |
 
-> Routing is React Navigation-based (`App.js` + `app/_layout.tsx`), not Expo Router.
+## Browser policy verification
 
-## Architecture snapshot
-
-```text
-app/
-  _layout.tsx                # Root navigation container + stack wiring
-  tabs/_layout.tsx           # Bottom tabs (Home, Favorites)
-  home/search/query.tsx      # Search screen entry
-  home/details/[id].tsx      # Details screen entry
-
-containers/                  # Screen-level orchestration (queries, mapping, mutations)
-components/                  # Reusable UI + views
-src/domain/                  # Entities and repository contracts
-src/repositories/            # API/storage/backup implementations
-src/providers/               # Repository dependency injection
-constants/                   # Colors, query keys, query client
-scripts/                     # Validation and workflow scripts
-```
-
-## Quick start
-
-### Prerequisites
-
-- Node.js 18+
-- npm (canonical package manager for this repo)
-
-### Install
+Legacy Playwright artifacts are read-only. For browser checks, use the cmux workflow in [`docs/browser-workflow.md`](docs/browser-workflow.md).
 
 ```bash
-git clone https://github.com/GOI17/VibeVault.git
-cd VibeVault
-npm install
+npm run verify:browser-policy
 ```
 
-### Environment variables
+Output labels: PASS / FAIL / BLOCKED.
 
-Use `.env.example` as the template:
+## For agents and contributors
 
-```bash
-cp .env.example .env
-```
-
-Populate required value:
-
-- `EXPO_PUBLIC_API_URL`
-
-Optional (only if using Google auth / backup flows):
-
-- `EXPO_PUBLIC_GOOGLE_CLIENT_ID`
-- `EXPO_PUBLIC_ANDROID_CLIENT_ID`
-- `EXPO_PUBLIC_IOS_CLIENT_ID`
-
-### Run
-
-```bash
-npm start
-```
-
-Then choose a target from Expo CLI (`i` / `a` / `w`) or use dedicated scripts below.
-
-## Scripts
-
-- `npm start` — start via `scripts/start-clean.js`
-- `npm run start:expo` — raw Expo start
-- `npm run android` — run Android target
-- `npm run ios` — run iOS target
-- `npm run web` — run web target
-- `npm run lint` — run Expo ESLint
-- `npm run reset-project` — legacy compatibility helper (non-destructive, deprecated)
-- `./node_modules/.bin/tsc --noEmit` — TypeScript check
-- `npm run verify:browser-policy` — browser policy harness
-- `npm run verify:stitch-ui-updates-phase1` — phase-1 UI invariants harness
-- `npm run predeploy` — export web build to `dist`
-- `npm run deploy` — publish `dist` to GitHub Pages via `gh-pages`
-
-## Verification workflow
-
-- Static checks:
-  - `npm run lint`
-  - `./node_modules/.bin/tsc --noEmit`
-- Browser-policy checks:
-  - `npm run verify:browser-policy`
-- UI policy checks:
-  - `npm run verify:stitch-ui-updates-phase1`
-
-For browser/visual checks, follow `docs/browser-workflow.md`.
-
-## Deployment
-
-Canonical web deployment path:
-
-```bash
-npm run predeploy
-npm run deploy
-```
-
-`homepage` is configured for GitHub Pages at `https://goi17.github.io/VibeVault`.
-
-## Web zoom policy
-
-- VibeVault applies a web zoom policy at app bootstrap (`App.js`) to reduce accidental zoom behaviors where technically appropriate.
-- The runtime policy keeps the viewport baseline at `initial-scale=1` and applies `touch-action: manipulation`.
-- Inputs are forced to `font-size: 16px` on web to avoid iOS focus-zoom behavior.
-- This is a best-effort web policy; browser accessibility zoom controls may still override restrictions.
-
-## GitHub issue workflow
-
-- Use issue forms under `.github/ISSUE_TEMPLATE/`:
-  - Bug report
-  - Feature request
-- Blank issues are disabled.
-- New issues are labeled `status:needs-review`.
-- Maintainers add `status:approved` before implementation PRs.
+Start with [`AGENTS.md`](AGENTS.md), then use [`docs/agent-guide.md`](docs/agent-guide.md) to choose the smallest useful project context for your task.
 
 ## License
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -1,0 +1,29 @@
+# Agent Guide
+
+Use this after `AGENTS.md` to choose the smallest useful project context before editing.
+
+## Quick path
+
+1. Read `AGENTS.md` for mandatory behavior and review rules.
+2. Pick only the docs that match the task.
+3. Prefer links over duplicated explanations.
+
+## Task routing
+
+| Task | Read |
+|---|---|
+| Product behavior or vocabulary | `docs/project-overview.md` |
+| Navigation, repositories, data flow, boundaries | `docs/architecture.md` |
+| Local setup, env vars, scripts | `docs/development.md` |
+| Checks, validation, PR readiness | `docs/verification.md` |
+| Web platform behavior | `docs/web-platform-policy.md` |
+| Browser or visual validation | `docs/browser-workflow.md` |
+| Deployment | `docs/deployment.md` |
+| Issues, labels, PR approval | `docs/github-workflow.md` |
+
+## Guardrails
+
+- Keep `README.md` human-facing and concise.
+- Keep `AGENTS.md` focused on agent behavior and repository rules.
+- Put long-lived project knowledge in scoped `docs/` files.
+- Do not change app behavior during documentation-only work.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,35 @@
+# Architecture
+
+VibeVault is an Expo / React Native app using React Navigation and repository boundaries. Keep UI, orchestration, domain contracts, and data adapters separated.
+
+## Stack
+
+| Area | Choice |
+|---|---|
+| Runtime | Expo SDK 55, React Native 0.83, React 19 |
+| Navigation | React Navigation stack + bottom tabs |
+| Cache state | TanStack Query |
+| Local persistence | AsyncStorage |
+| Validation/forms | Zod and Formik |
+
+> Routing is React Navigation-based (`App.js` + `app/_layout.tsx`), not Expo Router.
+
+## Repo shape
+
+```text
+app/                 # navigation entries and screens
+containers/          # queries, mapping, mutations
+components/          # reusable UI and views
+src/domain/          # entities and repository contracts
+src/repositories/    # API, storage, backup adapters
+src/providers/       # dependency injection
+constants/           # colors, query keys, query client
+scripts/             # validation and workflow scripts
+```
+
+## Boundaries
+
+- Domain contracts live in `src/domain`.
+- Adapter implementations live in `src/repositories`.
+- Containers orchestrate data; components render UI.
+- Do not reach across layers when a contract/container boundary exists.

--- a/docs/browser-workflow.md
+++ b/docs/browser-workflow.md
@@ -1,0 +1,39 @@
+# Browser Workflow
+
+Use cmux-browser for browser evidence. Playwright is not an allowed fallback.
+
+## Quick path
+
+1. Open the target app or route with `cmux browser open <url> --json`.
+2. Wait for `--load-state complete` before interacting.
+3. Capture an interactive snapshot for concrete refs.
+4. Take a screenshot only after the UI is stable.
+5. Record the commands, URL, surface id, and the verification result.
+
+## Surface selection
+
+If multiple cmux surfaces are available, choose the one that matches the target app/session. Do not interact with an unrelated surface.
+
+## Fallback policy
+
+If no cmux surface is available, stop the visual check and mark the check as `BLOCKED`.
+
+Do not switch to Playwright.
+
+If a browser/visual task cannot be completed with cmux-browser, the task MUST be treated as blocked rather than switching to Playwright.
+
+Legacy Playwright artifacts are read-only.
+
+## Evidence and pass criteria
+
+Record command, URL, surface id, snapshot/screenshot reference, observed result, and PASS / FAIL / BLOCKED outcome.
+
+The evidence bundle is the preserved artifact trail for the final verified state.
+
+A `PASS` means the evidence trail is reviewed, cmux was used, and Playwright was not used.
+
+## Verification
+
+```bash
+pnpm verify:browser-policy
+```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,24 @@
+# Deployment
+
+VibeVault deploys the web app to GitHub Pages.
+
+## Quick path
+
+```bash
+pnpm predeploy
+pnpm deploy
+```
+
+## Flow
+
+| Step | Command or workflow |
+|---|---|
+| Export web app | `pnpm predeploy` / `expo export -p web` |
+| Publish `dist` | `pnpm deploy` via `gh-pages` |
+| CI deployment | `.github/workflows/deploy.yml` |
+
+## GitHub Pages
+
+`homepage` is `https://goi17.github.io/VibeVault`.
+
+The workflow uses Node.js 20, pnpm 9.15.9, `vars.API_URL` as `EXPO_PUBLIC_API_URL`, `EXPO_PUBLIC_URL=/VibeVault`, and `fix-paths.js` before uploading the Pages artifact.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,36 @@
+# Development
+
+Use this for local setup, environment variables, and day-to-day scripts.
+
+## Quick path
+
+```bash
+git clone https://github.com/GOI17/VibeVault.git
+cd VibeVault
+pnpm install
+cp .env.example .env
+pnpm start
+```
+
+## Prerequisites
+
+- Node.js 18+
+- pnpm 9.15.9 from `package.json`
+
+## Environment variables
+
+Required: `EXPO_PUBLIC_API_URL`.
+
+Optional for Google auth / backup flows: `EXPO_PUBLIC_GOOGLE_CLIENT_ID`, `EXPO_PUBLIC_ANDROID_CLIENT_ID`, `EXPO_PUBLIC_IOS_CLIENT_ID`.
+
+## Scripts
+
+| Command | Purpose |
+|---|---|
+| `pnpm start` | Start via `scripts/start-clean.js`. |
+| `pnpm start:expo` | Start raw Expo CLI. |
+| `pnpm android` / `pnpm ios` / `pnpm web` | Run platform targets. |
+| `pnpm lint` | Run Expo ESLint. |
+| `./node_modules/.bin/tsc --noEmit` | TypeScript check. |
+| `pnpm verify:browser-policy` | Browser policy harness. |
+| `pnpm verify:stitch-ui-updates-phase1` | Phase-1 UI invariants harness. |

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -1,0 +1,17 @@
+# GitHub Workflow
+
+VibeVault uses issue forms and approval before implementation.
+
+## Issue workflow
+
+- Use `.github/ISSUE_TEMPLATE/` forms.
+- Blank issues are disabled.
+- New issues start with `status:needs-review`.
+- Maintainers add `status:approved` before implementation PRs.
+
+## PR guardrails
+
+- Link the approved issue in the PR body.
+- Use conventional commits.
+- Do not add `Co-Authored-By` or AI attribution trailers.
+- Keep docs-only PRs docs-only unless the issue asks for code.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -1,0 +1,21 @@
+# Project Overview
+
+VibeVault is a React Native + Expo app for discovering movies and series, managing favorites, and viewing detailed title metadata on mobile and web.
+
+## Capabilities
+
+- Browse a curated home feed.
+- Search titles from the header flow.
+- Open Details with synopsis, cast, release date, watch options, and season/episode metadata.
+- Add/remove favorites with double press.
+- Create manual favorites and filter favorites by media type.
+- Backup and restore favorites through the configured backup repository.
+
+## Vocabulary
+
+| Term | Meaning |
+|---|---|
+| Title | A movie or series shown in VibeVault. |
+| Details | The full metadata screen for a title. |
+| Favorite | A locally persisted saved title. |
+| Manual favorite | A user-created favorite not sourced from the catalog feed. |

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,28 @@
+# Verification
+
+Use this to choose checks for a change. Do not run a production build unless explicitly requested.
+
+## Code changes
+
+```bash
+./node_modules/.bin/eslint <touched files>
+./node_modules/.bin/tsc --noEmit
+```
+
+For full lint, run `pnpm lint`.
+
+## Browser and UI policy checks
+
+| Command | Purpose |
+|---|---|
+| `pnpm verify:browser-policy` | Validates browser policy assumptions. |
+| `pnpm verify:stitch-ui-updates-phase1` | Validates phase-1 UI invariants. |
+
+## Documentation-only changes
+
+1. Verify the diff only touches intended docs/metadata.
+2. Check links and filenames.
+3. Do not run app builds.
+4. Run markdown tooling only if the repo adds it.
+
+See `docs/browser-workflow.md` for browser evidence rules.

--- a/docs/web-platform-policy.md
+++ b/docs/web-platform-policy.md
@@ -1,0 +1,18 @@
+# Web Platform Policy
+
+Use this for browser-specific behavior that should survive UI and bootstrap changes.
+
+## Web zoom policy
+
+VibeVault applies a web zoom policy at app bootstrap (`App.js`) to reduce accidental zoom behavior where technically appropriate.
+
+The runtime policy keeps `initial-scale=1`, applies `touch-action: manipulation`, and forces inputs to `font-size: 16px` on web to avoid iOS focus zoom behavior.
+
+This is best-effort. Browser accessibility zoom controls may still override restrictions.
+
+## Agent guardrails
+
+- Do not remove the web policy while changing bootstrap or layout code.
+- Treat browser behavior as platform-specific.
+- Run `pnpm verify:browser-policy` when touching browser policy code.
+- Use `docs/browser-workflow.md` for cmux browser evidence.


### PR DESCRIPTION
Closes #53

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Keeps `README.md` human-facing and moves detailed project knowledge into scoped docs.
- Adds `docs/agent-guide.md` as the routing map for agents before feature work.
- Preserves the executable browser-policy docs contract with `docs/browser-workflow.md`.

## Changes

| File | Change |
|------|--------|
| `README.md` | Shortened into overview, quick start, and docs index. |
| `AGENTS.md` | Added pointer to project guardrails. |
| `docs/agent-guide.md` | Added task-to-doc routing for agents. |
| `docs/*.md` | Added focused docs for architecture, development, verification, deployment, web policy, browser workflow, GitHub workflow, and project overview. |

## Test Plan

- [x] Browser policy verification: `node scripts/verify-browser-policy.js`
- [x] Markdown local links checked with a small static script
- [x] Confirmed diff is docs-only and under 400 changed lines
- [x] No production build run

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
