### PR TITLE
feat(tracking): add watched progress tracking

### DIFF
--- a/components/views/DetailsView.tsx
+++ b/components/views/DetailsView.tsx
@@ -1,8 +1,9 @@
 import { Image } from "expo-image";
 import type { ReactElement } from "react";
-import { ScrollView, Text, View } from "react-native";
+import { ScrollView, Text, TouchableOpacity, View } from "react-native";
 
 import type { Season } from "@/domain/entities/Movie";
+import { createEpisodeWatchedKey } from "@/domain/entities/WatchedProgress";
 import { useThemePreference } from "@/providers/ThemePreferenceProvider";
 
 interface DetailsViewProps {
@@ -16,6 +17,13 @@ interface DetailsViewProps {
   seasons?: Season[];
   imageSrc?: string;
   mediaType: "movie" | "series";
+  isMovieWatched: boolean;
+  isUpdatingMovieWatched: boolean;
+  onToggleMovieWatched: () => void;
+  watchedEpisodeKeys: ReadonlySet<string>;
+  isUpdatingEpisodeWatched: boolean;
+  onToggleEpisodeWatched: (seasonNumber: number, episodeNumber: number, watched: boolean) => void;
+  seriesProgress: { watched: number; total: number };
 }
 
 export function DetailsView({
@@ -29,6 +37,13 @@ export function DetailsView({
   seasons,
   imageSrc,
   mediaType,
+  isMovieWatched,
+  isUpdatingMovieWatched,
+  onToggleMovieWatched,
+  watchedEpisodeKeys,
+  isUpdatingEpisodeWatched,
+  onToggleEpisodeWatched,
+  seriesProgress,
 }: DetailsViewProps): ReactElement {
   const { palette } = useThemePreference();
   const fallbackImage = require("../../assets/images/logo.png");
@@ -60,6 +75,36 @@ export function DetailsView({
 
       <Text style={{ color: palette.text, fontSize: 30, lineHeight: 34, fontWeight: "800" }}>{title}</Text>
 
+      {mediaType === "movie" ? (
+        <TouchableOpacity
+          onPress={onToggleMovieWatched}
+          disabled={isUpdatingMovieWatched}
+          accessibilityRole="button"
+          accessibilityState={{ selected: isMovieWatched, disabled: isUpdatingMovieWatched }}
+          accessibilityLabel={isMovieWatched ? "Mark movie as unwatched" : "Mark movie as watched"}
+          style={{
+            alignSelf: "flex-start",
+            backgroundColor: isMovieWatched ? palette.shellChipActive : palette.shellSurface,
+            borderColor: isMovieWatched ? palette.shellChipActive : palette.shellBorder,
+            borderRadius: 18,
+            borderWidth: 1,
+            opacity: isUpdatingMovieWatched ? 0.6 : 1,
+            paddingHorizontal: 16,
+            paddingVertical: 10,
+          }}
+        >
+          <Text
+            style={{
+              color: isMovieWatched ? palette.shellChipTextActive : palette.text,
+              fontSize: 15,
+              fontWeight: "700",
+            }}
+          >
+            {isMovieWatched ? "Watched" : "Mark as watched"}
+          </Text>
+        </TouchableOpacity>
+      ) : null}
+
       <View style={{ gap: 8 }}>
         <Text style={{ color: palette.shellMutedText, fontSize: 12, fontWeight: "700", textTransform: "uppercase" }}>Descripción / Sinopsis</Text>
         <Text style={{ color: palette.text, fontSize: 16, lineHeight: 24 }}>{description || "No disponible"}</Text>
@@ -89,6 +134,9 @@ export function DetailsView({
           <Text style={{ color: palette.shellMutedText, fontSize: 12, fontWeight: "700", textTransform: "uppercase" }}>
             Temporadas y episodios
           </Text>
+          <Text style={{ color: palette.text, fontSize: 16, fontWeight: "700" }}>
+            Progress: {seriesProgress.watched}/{seriesProgress.total} watched
+          </Text>
 
           {seasons && seasons.length > 0 ? (
             seasons.map((season) => (
@@ -100,16 +148,54 @@ export function DetailsView({
                   {season.title || `Temporada ${season.seasonNumber}`}
                 </Text>
 
-                {season.episodes.map((episode) => (
-                  <View key={`episode-${season.seasonNumber}-${episode.episodeNumber}`} style={{ gap: 2 }}>
-                    <Text style={{ color: palette.text, fontSize: 15 }}>
-                      E{episode.episodeNumber}. {episode.title}
-                    </Text>
-                    <Text style={{ color: palette.shellMutedText, fontSize: 13 }}>
-                      Lanzamiento: {episode.releaseDate || "No disponible"}
-                    </Text>
-                  </View>
-                ))}
+                {season.episodes.map((episode) => {
+                  const episodeKey = createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber);
+                  const isEpisodeWatched = watchedEpisodeKeys.has(episodeKey);
+
+                  return (
+                    <TouchableOpacity
+                      key={`episode-${season.seasonNumber}-${episode.episodeNumber}`}
+                      onPress={() =>
+                        onToggleEpisodeWatched(
+                          season.seasonNumber,
+                          episode.episodeNumber,
+                          !isEpisodeWatched
+                        )
+                      }
+                      disabled={isUpdatingEpisodeWatched}
+                      accessibilityRole="checkbox"
+                      accessibilityState={{ checked: isEpisodeWatched, disabled: isUpdatingEpisodeWatched }}
+                      accessibilityLabel={`${isEpisodeWatched ? "Unmark" : "Mark"} season ${season.seasonNumber} episode ${episode.episodeNumber} as watched`}
+                      style={{
+                        backgroundColor: isEpisodeWatched ? palette.shellChipActive : palette.shellBackground,
+                        borderColor: isEpisodeWatched ? palette.shellChipActive : palette.shellBorder,
+                        borderRadius: 10,
+                        borderWidth: 1,
+                        gap: 2,
+                        opacity: isUpdatingEpisodeWatched ? 0.6 : 1,
+                        padding: 10,
+                      }}
+                    >
+                      <Text
+                        style={{
+                          color: isEpisodeWatched ? palette.shellChipTextActive : palette.text,
+                          fontSize: 15,
+                          fontWeight: isEpisodeWatched ? "700" : "400",
+                        }}
+                      >
+                        {isEpisodeWatched ? "✓ " : ""}E{episode.episodeNumber}. {episode.title}
+                      </Text>
+                      <Text
+                        style={{
+                          color: isEpisodeWatched ? palette.shellChipTextActive : palette.shellMutedText,
+                          fontSize: 13,
+                        }}
+                      >
+                        Lanzamiento: {episode.releaseDate || "No disponible"}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
               </View>
             ))
           ) : (

--- a/constants/query.ts
+++ b/constants/query.ts
@@ -16,6 +16,14 @@ type FavoritesByMediaTypeQuery = {
   queryKey: ["movies", "favorites", MediaType | "all"];
 };
 
+type WatchedMovieQuery = {
+  queryKey: ["watched-progress", "movie", string];
+};
+
+type WatchedEpisodesQuery = {
+  queryKey: ["watched-progress", "episodes", string];
+};
+
 export const queryOptions = {
   movies: {
     all: (query: string): MoviesAllQuery => {
@@ -37,6 +45,18 @@ export const queryOptions = {
     favoritesByMediaType: (mediaType: MediaType | undefined): FavoritesByMediaTypeQuery => {
       return {
         queryKey: ["movies", "favorites", mediaType ?? "all"],
+      };
+    },
+  },
+  watchedProgress: {
+    movie: (mediaId: string): WatchedMovieQuery => {
+      return {
+        queryKey: ["watched-progress", "movie", mediaId],
+      };
+    },
+    episodes: (mediaId: string): WatchedEpisodesQuery => {
+      return {
+        queryKey: ["watched-progress", "episodes", mediaId],
       };
     },
   },

--- a/containers/DetailsContainer.tsx
+++ b/containers/DetailsContainer.tsx
@@ -1,14 +1,22 @@
-import { useQuery } from "@tanstack/react-query";
-import type { ReactElement } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, type ReactElement } from "react";
 import { z } from "zod";
 
 import { DetailsView } from "@/components/views/DetailsView";
 import type { RootStackParamList } from "@/app/navigation/types";
 import { useRepositories } from "@/providers/RepositoryProvider";
 import { SeasonSchema } from "@/domain/entities/Movie";
+import { createEpisodeWatchedKey, type WatchedEpisodeInput } from "@/domain/entities/WatchedProgress";
+import { queryOptions } from "@/constants/query";
 
 interface DetailsContainerProps {
   params: RootStackParamList["Details"];
+}
+
+interface EpisodeToggleInput {
+  seasonNumber: number;
+  episodeNumber: number;
+  watched: boolean;
 }
 
 function normalizeStringList(value: unknown): string[] | undefined {
@@ -54,7 +62,8 @@ function normalizeSeasons(
 }
 
 export function DetailsContainer({ params }: DetailsContainerProps): ReactElement {
-  const { movieRepository, favoriteRepository } = useRepositories();
+  const { movieRepository, favoriteRepository, watchedProgressRepository } = useRepositories();
+  const queryClient = useQueryClient();
   const isManualFavorite = params.source === "manual" || params.id.startsWith("custom-");
 
   const { data, isLoading, error } = useQuery({
@@ -67,6 +76,39 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
     queryKey: ["favorites", "details", params.id],
     queryFn: () => favoriteRepository.getById(params.id),
     enabled: isManualFavorite,
+  });
+
+  const { data: watchedMovieStatus } = useQuery({
+    ...queryOptions.watchedProgress.movie(params.id),
+    queryFn: () => watchedProgressRepository.getMovieStatus(params.id),
+    enabled: Boolean(params.id),
+  });
+
+  const { data: watchedEpisodeStatuses = [] } = useQuery({
+    ...queryOptions.watchedProgress.episodes(params.id),
+    queryFn: () => watchedProgressRepository.getEpisodeStatuses(params.id),
+    enabled: Boolean(params.id),
+  });
+
+  const toggleMovieWatchedMutation = useMutation({
+    mutationFn: (watched: boolean) => watchedProgressRepository.setMovieWatched(params.id, watched),
+    onSuccess: () => {
+      void queryClient.invalidateQueries(queryOptions.watchedProgress.movie(params.id));
+    },
+  });
+
+  const toggleEpisodeWatchedMutation = useMutation({
+    mutationFn: (input: EpisodeToggleInput) => {
+      const watchedInput: WatchedEpisodeInput = {
+        mediaId: params.id,
+        ...input,
+      };
+
+      return watchedProgressRepository.setEpisodeWatched(watchedInput);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries(queryOptions.watchedProgress.episodes(params.id));
+    },
   });
 
   const missingDetails = !isManualFavorite && !isLoading && !error && data === null;
@@ -94,7 +136,32 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
   );
   const imageSrc = data?.primaryImage?.url || manualDetails?.url || params.imageSrc;
 
-  const hasRenderableDetails = Boolean(title && title.trim().length > 0);
+  const watchedEpisodeKeys = useMemo(() => {
+    return new Set(
+      watchedEpisodeStatuses
+        .filter((episode) => episode.watched)
+        .map((episode) => createEpisodeWatchedKey(episode.seasonNumber, episode.episodeNumber))
+    );
+  }, [watchedEpisodeStatuses]);
+
+  const seriesProgress = useMemo(() => {
+    let watched = 0;
+    let total = 0;
+
+    seasons?.forEach((season) => {
+      season.episodes.forEach((episode) => {
+        total += 1;
+        if (watchedEpisodeKeys.has(createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber))) {
+          watched += 1;
+        }
+      });
+    });
+
+    return {
+      watched,
+      total,
+    };
+  }, [seasons, watchedEpisodeKeys]);
 
   const hasRequiredBaseFields = Boolean(
     title &&
@@ -149,6 +216,15 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
       seasons={seasons}
       imageSrc={imageSrc}
       mediaType={mediaType}
+      isMovieWatched={Boolean(watchedMovieStatus?.watched)}
+      isUpdatingMovieWatched={toggleMovieWatchedMutation.isPending}
+      onToggleMovieWatched={() => toggleMovieWatchedMutation.mutate(!watchedMovieStatus?.watched)}
+      watchedEpisodeKeys={watchedEpisodeKeys}
+      isUpdatingEpisodeWatched={toggleEpisodeWatchedMutation.isPending}
+      onToggleEpisodeWatched={(seasonNumber, episodeNumber, watched) =>
+        toggleEpisodeWatchedMutation.mutate({ seasonNumber, episodeNumber, watched })
+      }
+      seriesProgress={seriesProgress}
     />
   );
 }

--- a/src/domain/entities/WatchedProgress.ts
+++ b/src/domain/entities/WatchedProgress.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+const WatchedAtSchema = z.string().datetime();
+
+export const WatchedMovieSchema = z.object({
+  mediaId: z.string().trim().min(1),
+  mediaType: z.literal("movie"),
+  watched: z.boolean(),
+  watchedAt: WatchedAtSchema.optional(),
+});
+
+export const WatchedEpisodeSchema = z.object({
+  mediaId: z.string().trim().min(1),
+  mediaType: z.literal("series"),
+  seasonNumber: z.number().int().nonnegative(),
+  episodeNumber: z.number().int().nonnegative(),
+  watched: z.boolean(),
+  watchedAt: WatchedAtSchema.optional(),
+});
+
+export const WatchedEpisodeInputSchema = WatchedEpisodeSchema.pick({
+  mediaId: true,
+  seasonNumber: true,
+  episodeNumber: true,
+  watched: true,
+});
+
+export const WatchedProgressStoreSchema = z.object({
+  movies: z.array(WatchedMovieSchema).default([]),
+  episodes: z.array(WatchedEpisodeSchema).default([]),
+});
+
+export type WatchedMovie = z.infer<typeof WatchedMovieSchema>;
+export type WatchedEpisode = z.infer<typeof WatchedEpisodeSchema>;
+export type WatchedEpisodeInput = z.infer<typeof WatchedEpisodeInputSchema>;
+export type WatchedProgressStore = z.infer<typeof WatchedProgressStoreSchema>;
+
+export function createEpisodeWatchedKey(seasonNumber: number, episodeNumber: number): string {
+  return `${seasonNumber}:${episodeNumber}`;
+}
+
+export function validateWatchedProgressStore(data: unknown): WatchedProgressStore {
+  return WatchedProgressStoreSchema.parse(data);
+}

--- a/src/domain/repositories/IWatchedProgressRepository.ts
+++ b/src/domain/repositories/IWatchedProgressRepository.ts
@@ -1,0 +1,17 @@
+import type {
+  WatchedEpisode,
+  WatchedEpisodeInput,
+  WatchedMovie,
+} from "@/domain/entities/WatchedProgress";
+
+export interface IWatchedProgressRepository {
+  getMovieStatus(mediaId: string): Promise<WatchedMovie | null>;
+
+  setMovieWatched(mediaId: string, watched: boolean): Promise<WatchedMovie>;
+
+  getEpisodeStatuses(mediaId: string): Promise<WatchedEpisode[]>;
+
+  setEpisodeWatched(input: WatchedEpisodeInput): Promise<WatchedEpisode>;
+
+  clearMediaProgress(mediaId: string): Promise<void>;
+}

--- a/src/providers/RepositoryProvider.tsx
+++ b/src/providers/RepositoryProvider.tsx
@@ -2,16 +2,19 @@ import { createContext, useContext, useMemo, type ReactElement, type ReactNode }
 import type { IFavoriteRepository } from "@/domain/repositories/IFavoriteRepository";
 import type { IMovieRepository } from "@/domain/repositories/IMovieRepository";
 import type { IBackupRepository } from "@/domain/repositories/IBackupRepository";
+import type { IWatchedProgressRepository } from "@/domain/repositories/IWatchedProgressRepository";
 import type { Favorite } from "@/domain/entities/Favorite";
 import { AsyncStorageFavoriteRepository } from "@/repositories/AsyncStorageFavoriteRepository";
 import { APIMovieRepository } from "@/repositories/APIMovieRepository";
 import { GoogleDriveBackupRepository } from "@/repositories/GoogleDriveBackupRepository";
+import { AsyncStorageWatchedProgressRepository } from "@/repositories/AsyncStorageWatchedProgressRepository";
 import { getStoredToken, signInWithGoogle } from "@/repositories/googleAuth";
 
 interface RepositoryContextType {
   favoriteRepository: IFavoriteRepository;
   movieRepository: IMovieRepository;
   backupRepository: IBackupRepository<Favorite>;
+  watchedProgressRepository: IWatchedProgressRepository;
 }
 
 const RepositoryContext = createContext<RepositoryContextType | undefined>(
@@ -31,6 +34,7 @@ export function RepositoryProvider({ children }: RepositoryProviderProps): React
         signInWithGoogle,
         getStoredToken,
       }),
+      watchedProgressRepository: new AsyncStorageWatchedProgressRepository(),
     };
   }, []);
 

--- a/src/repositories/AsyncStorageWatchedProgressRepository.ts
+++ b/src/repositories/AsyncStorageWatchedProgressRepository.ts
@@ -1,0 +1,112 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import {
+  createEpisodeWatchedKey,
+  validateWatchedProgressStore,
+  type WatchedEpisode,
+  type WatchedEpisodeInput,
+  type WatchedMovie,
+  type WatchedProgressStore,
+} from "@/domain/entities/WatchedProgress";
+import type { IWatchedProgressRepository } from "@/domain/repositories/IWatchedProgressRepository";
+
+const STORAGE_KEY = "watched_progress";
+
+function emptyStore(): WatchedProgressStore {
+  return {
+    movies: [],
+    episodes: [],
+  };
+}
+
+function createWatchedAt(watched: boolean): string | undefined {
+  return watched ? new Date().toISOString() : undefined;
+}
+
+export class AsyncStorageWatchedProgressRepository implements IWatchedProgressRepository {
+  async getMovieStatus(mediaId: string): Promise<WatchedMovie | null> {
+    const store = await this.readStore();
+    return store.movies.find((movie) => movie.mediaId === mediaId) ?? null;
+  }
+
+  async setMovieWatched(mediaId: string, watched: boolean): Promise<WatchedMovie> {
+    const store = await this.readStore();
+    const record: WatchedMovie = {
+      mediaId,
+      mediaType: "movie",
+      watched,
+      watchedAt: createWatchedAt(watched),
+    };
+
+    const remainingMovies = store.movies.filter((movie) => movie.mediaId !== mediaId);
+    const nextStore = validateWatchedProgressStore({
+      ...store,
+      movies: watched ? [...remainingMovies, record] : remainingMovies,
+    });
+
+    await this.writeStore(nextStore);
+    return record;
+  }
+
+  async getEpisodeStatuses(mediaId: string): Promise<WatchedEpisode[]> {
+    const store = await this.readStore();
+    return store.episodes.filter((episode) => episode.mediaId === mediaId && episode.watched);
+  }
+
+  async setEpisodeWatched(input: WatchedEpisodeInput): Promise<WatchedEpisode> {
+    const store = await this.readStore();
+    const episodeKey = createEpisodeWatchedKey(input.seasonNumber, input.episodeNumber);
+    const record: WatchedEpisode = {
+      ...input,
+      mediaType: "series",
+      watchedAt: createWatchedAt(input.watched),
+    };
+
+    const remainingEpisodes = store.episodes.filter((episode) => {
+      if (episode.mediaId !== input.mediaId) {
+        return true;
+      }
+
+      return createEpisodeWatchedKey(episode.seasonNumber, episode.episodeNumber) !== episodeKey;
+    });
+
+    const nextStore = validateWatchedProgressStore({
+      ...store,
+      episodes: input.watched ? [...remainingEpisodes, record] : remainingEpisodes,
+    });
+
+    await this.writeStore(nextStore);
+    return record;
+  }
+
+  async clearMediaProgress(mediaId: string): Promise<void> {
+    const store = await this.readStore();
+    const nextStore = validateWatchedProgressStore({
+      movies: store.movies.filter((movie) => movie.mediaId !== mediaId),
+      episodes: store.episodes.filter((episode) => episode.mediaId !== mediaId),
+    });
+
+    await this.writeStore(nextStore);
+  }
+
+  private async readStore(): Promise<WatchedProgressStore> {
+    const storage = await AsyncStorage.getItem(STORAGE_KEY);
+
+    if (!storage) {
+      return emptyStore();
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(storage);
+      return validateWatchedProgressStore(parsed);
+    } catch (error) {
+      console.error("Failed to parse watched progress from storage:", error);
+      return emptyStore();
+    }
+  }
+
+  private async writeStore(store: WatchedProgressStore): Promise<void> {
+    const validatedStore = validateWatchedProgressStore(store);
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(validatedStore));
+  }
+}


### PR DESCRIPTION
Closes #55

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds repository-backed watched progress tracking for movies and TV episodes.
- Persists watched state in AsyncStorage behind a dedicated domain repository contract.
- Displays movie watched toggles, episode watched controls, and derived series progress on Details.

## Changes
| File | Change |
|------|--------|
| `src/domain/entities/WatchedProgress.ts` | Adds watched movie/episode schemas, types, persisted store validation, and episode key helper. |
| `src/domain/repositories/IWatchedProgressRepository.ts` | Adds watched progress repository contract. |
| `src/repositories/AsyncStorageWatchedProgressRepository.ts` | Adds AsyncStorage-backed implementation with dedicated storage key and validation. |
| `src/providers/RepositoryProvider.tsx` | Injects the watched progress repository. |
| `constants/query.ts` | Adds watched-progress query keys. |
| `containers/DetailsContainer.tsx` | Loads/mutates watched state and derives series progress from watched episode records. |
| `components/views/DetailsView.tsx` | Adds movie watched toggle, episode watched controls, accessibility state, and progress display. |

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/eslint src/domain/entities/WatchedProgress.ts src/domain/repositories/IWatchedProgressRepository.ts src/repositories/AsyncStorageWatchedProgressRepository.ts src/providers/RepositoryProvider.tsx constants/query.ts containers/DetailsContainer.tsx components/views/DetailsView.tsx`
- [x] Pre-commit static review passed: `STATUS: PASSED`
- [x] Confirmed review workload stayed below 400 changed lines after trimming comments: 374 insertions, 15 deletions.
- [x] No production build run.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran applicable verification for changed files
- [x] Docs updated if behavior changed: not needed for this UI/data feature slice
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
