### PR TITLE
feat(results): use mobile list view and sort favorites

### DIFF
--- a/components/Masonry.tsx
+++ b/components/Masonry.tsx
@@ -27,6 +27,8 @@ interface MasonryListProps {
   isFavorites?: boolean;
   isFavoritesLoading?: boolean;
   showLayoutToggle?: boolean;
+  forceListOnMobile?: boolean;
+  mobileBreakpoint?: number;
   topInset?: number;
   offsetTop?: number;
   favoriteIds?: ReadonlySet<string>;
@@ -41,6 +43,8 @@ export default function MasonryList({
   isFavorites = false,
   isFavoritesLoading = false,
   showLayoutToggle = true,
+  forceListOnMobile = false,
+  mobileBreakpoint = 768,
   topInset = 0,
   offsetTop = 0,
   favoriteIds,
@@ -53,9 +57,11 @@ export default function MasonryList({
   const { width } = useWindowDimensions();
   const { palette } = useThemePreference();
   const fallbackImage = require("../assets/images/logo.png");
+  const isListForcedOnMobile = forceListOnMobile && width < mobileBreakpoint;
+  const effectiveView = isListForcedOnMobile ? "list" : view;
 
   const numColumns =
-    view === "list"
+    effectiveView === "list"
       ? 1
       : width >= 1100
         ? 4
@@ -70,12 +76,12 @@ export default function MasonryList({
   const favoriteMembershipKey = JSON.stringify({
     favoriteIds: favoriteIds ? Array.from(favoriteIds).sort() : [],
     recentlyAddedIds: recentlyAddedIds ? Array.from(recentlyAddedIds).sort() : [],
-    view,
+    view: effectiveView,
   });
 
   return (
     <View style={{ flex: 1, marginTop: offsetTop }}>
-      {showLayoutToggle && width < 768 && (
+      {showLayoutToggle && width < mobileBreakpoint && !isListForcedOnMobile && (
         <Pressable
           onPress={() => setView((prev) => (prev === "grid" ? "list" : "grid"))}
           style={[
@@ -109,7 +115,7 @@ export default function MasonryList({
             <MasonryItem
               item={item}
               isFavorite={isFavorite}
-              view={view}
+              view={effectiveView}
               onAddFavorite={() => onAddFavorite?.(item)}
               onRemoveFavorite={() => onRemoveFavorite?.(item)}
               onOpenDetails={() => onOpenDetails?.(item)}

--- a/components/views/FavoritesView.tsx
+++ b/components/views/FavoritesView.tsx
@@ -8,6 +8,7 @@ import type { MediaType } from "@/constants/query";
 import { useThemePreference } from "@/providers/ThemePreferenceProvider";
 
 type FilterOption = MediaType | undefined;
+export type FavoriteSortDirection = "newest" | "oldest";
 
 const FILTER_OPTIONS: { label: string; value: FilterOption }[] = [
   { label: "All", value: undefined },
@@ -15,9 +16,16 @@ const FILTER_OPTIONS: { label: string; value: FilterOption }[] = [
   { label: "Series", value: "series" },
 ];
 
+const SORT_OPTIONS: { label: string; value: FavoriteSortDirection }[] = [
+  { label: "Newest", value: "newest" },
+  { label: "Oldest", value: "oldest" },
+];
+
 interface FavoritesViewProps {
   filter: FilterOption;
   onFilterChange: (value: FilterOption) => void;
+  sortDirection: FavoriteSortDirection;
+  onSortDirectionChange: (value: FavoriteSortDirection) => void;
   onGoHome: () => void;
   isLoading: boolean;
   errorMessage?: string;
@@ -31,6 +39,8 @@ interface FavoritesViewProps {
 export function FavoritesView({
   filter,
   onFilterChange,
+  sortDirection,
+  onSortDirectionChange,
   onGoHome,
   isLoading,
   errorMessage,
@@ -67,7 +77,7 @@ export function FavoritesView({
         >
           <Text style={{ color: palette.text, fontWeight: "600" }}>Go to Home</Text>
         </TouchableOpacity>
-        <View style={{ flexDirection: "row", gap: 10 }}>
+        <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 10 }}>
           {FILTER_OPTIONS.map((option) => (
             <TouchableOpacity
               key={option.label}
@@ -92,6 +102,43 @@ export function FavoritesView({
             </TouchableOpacity>
           ))}
         </View>
+        <View style={{ gap: 8 }}>
+          <Text style={{ color: palette.shellMutedText, fontSize: 13, fontWeight: "700" }}>
+            Sort by date added
+          </Text>
+          <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 10 }}>
+            {SORT_OPTIONS.map((option) => (
+              <TouchableOpacity
+                key={option.value}
+                onPress={() => onSortDirectionChange(option.value)}
+                accessibilityRole="button"
+                accessibilityLabel={`Sort favorites by date added: ${option.label.toLowerCase()} first`}
+                style={{
+                  paddingHorizontal: 16,
+                  paddingVertical: 8,
+                  borderRadius: 20,
+                  backgroundColor:
+                    sortDirection === option.value ? palette.shellChipActive : palette.shellSurface,
+                  borderWidth: 1,
+                  borderColor:
+                    sortDirection === option.value ? palette.shellChipActive : palette.shellBorder,
+                }}
+              >
+                <Text
+                  style={{
+                    color:
+                      sortDirection === option.value
+                        ? palette.shellChipTextActive
+                        : palette.shellChipTextIdle,
+                    fontWeight: sortDirection === option.value ? "bold" : "normal",
+                  }}
+                >
+                  {option.label}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
       </View>
 
       <View style={{ flex: 1 }}>
@@ -100,6 +147,7 @@ export function FavoritesView({
           isFavorites
           isFavoritesLoading={isLoading}
           showLayoutToggle={false}
+          forceListOnMobile
           topInset={0}
           favoriteIds={favoriteIds}
           onAddFavorite={onAddFavorite}

--- a/components/views/SearchView.tsx
+++ b/components/views/SearchView.tsx
@@ -53,6 +53,7 @@ export function SearchView({
       <MasonryList
         data={data}
         isFavorites={false}
+        forceListOnMobile
         favoriteIds={favoriteIds}
         onAddFavorite={onAddFavorite}
         onRemoveFavorite={onRemoveFavorite}

--- a/containers/FavoritesContainer.tsx
+++ b/containers/FavoritesContainer.tsx
@@ -3,17 +3,40 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigation, type NavigationProp } from "@react-navigation/native";
 
 import type { RootStackParamList } from "@/app/navigation/types";
-import { FavoritesView } from "@/components/views/FavoritesView";
+import { FavoritesView, type FavoriteSortDirection } from "@/components/views/FavoritesView";
 import { queryOptions } from "@/constants/query";
+import type { Favorite } from "@/domain/entities/Favorite";
 import { useFavoriteMutations } from "@/hooks/useFavoriteMutations";
 import { useRepositories } from "@/providers/RepositoryProvider";
 
 type FilterOption = "movie" | "series" | undefined;
 
+function getFavoriteAddedAtTime(favorite: Favorite): number {
+  if (!favorite.addedAt) {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  const addedAtTime = Date.parse(favorite.addedAt);
+
+  return Number.isNaN(addedAtTime) ? Number.NEGATIVE_INFINITY : addedAtTime;
+}
+
+function sortFavoritesByAddedAt(favorites: Favorite[], direction: FavoriteSortDirection): Favorite[] {
+  return [...favorites].sort((first, second) => {
+    const firstAddedAt = getFavoriteAddedAtTime(first);
+    const secondAddedAt = getFavoriteAddedAtTime(second);
+
+    return direction === "newest"
+      ? secondAddedAt - firstAddedAt
+      : firstAddedAt - secondAddedAt;
+  });
+}
+
 export function FavoritesContainer(): ReactElement {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const { favoriteRepository } = useRepositories();
   const [filter, setFilter] = useState<FilterOption>(undefined);
+  const [sortDirection, setSortDirection] = useState<FavoriteSortDirection>("newest");
   const { data, isLoading, error } = useQuery({
     ...queryOptions.movies.favoritesByMediaType(filter),
     queryFn: () => favoriteRepository.getByMediaType(filter),
@@ -21,25 +44,27 @@ export function FavoritesContainer(): ReactElement {
   const { addFavorite, removeFavorite } = useFavoriteMutations();
 
   const favoriteIds = new Set(data?.map((item) => item.id) ?? []);
+  const sortedFavorites = sortFavoritesByAddedAt(data ?? [], sortDirection);
 
-  const masonryData =
-    data?.map((item) => ({
-        key: item.id,
-        imageSrc: item.url,
-        title: item.title,
-        mediaType: item.mediaType,
-        description: item.description,
-        cast: item.cast,
-        releaseDate: item.releaseDate,
-        whereToWatch: item.whereToWatch || (item.platform ? [item.platform] : undefined),
-        seasons: item.seasons,
-        source: item.source,
-      })) || [];
+  const masonryData = sortedFavorites.map((item) => ({
+    key: item.id,
+    imageSrc: item.url,
+    title: item.title,
+    mediaType: item.mediaType,
+    description: item.description,
+    cast: item.cast,
+    releaseDate: item.releaseDate,
+    whereToWatch: item.whereToWatch || (item.platform ? [item.platform] : undefined),
+    seasons: item.seasons,
+    source: item.source,
+  }));
 
   return (
     <FavoritesView
       filter={filter}
       onFilterChange={setFilter}
+      sortDirection={sortDirection}
+      onSortDirectionChange={setSortDirection}
       onGoHome={() => navigation.navigate("Tabs", { screen: "Home" })}
       isLoading={isLoading}
       errorMessage={error?.message}


### PR DESCRIPTION
Closes #56

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds opt-in mobile list rendering to the shared Masonry list without changing default callers.
- Makes Search/results and Favorites use list cards on mobile screens.
- Adds Favorites sorting by date added with newest/oldest controls.

## Changes
| File | Change |
|------|--------|
| `components/Masonry.tsx` | Added `forceListOnMobile` and `mobileBreakpoint`, plus `effectiveView` for columns, item rendering, and toggle visibility. |
| `components/views/SearchView.tsx` | Opted Search results into mobile list UI. |
| `components/views/FavoritesView.tsx` | Opted Favorites into mobile list UI and added date-added sort controls. |
| `containers/FavoritesContainer.tsx` | Added presentation-layer sorting by existing `Favorite.addedAt`. |

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/eslint components/Masonry.tsx components/views/SearchView.tsx components/views/FavoritesView.tsx containers/FavoritesContainer.tsx`
- [x] Fresh static review passed during commit hook
- [x] Production build not run per project rule

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant verification for modified TypeScript/TSX files
- [x] Docs updated if behavior changed — not needed for this UI-only feature
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
