### PR TITLE
fix(details): restore details page scrolling

### DIFF
--- a/app/home/details/[id].tsx
+++ b/app/home/details/[id].tsx
@@ -1,11 +1,16 @@
-import { useRoute, type RouteProp } from "@react-navigation/native";
-import type { ReactElement } from "react";
+import { useNavigation, useRoute, type NavigationProp, type RouteProp } from "@react-navigation/native";
+import { useLayoutEffect, type ReactElement } from "react";
 
 import { DetailsContainer } from "@/containers/DetailsContainer";
 import type { RootStackParamList } from "@/app/navigation/types";
 
 export default function DetailsScreen(): ReactElement {
   const route = useRoute<RouteProp<RootStackParamList, "Details">>();
+  const navigation = useNavigation<NavigationProp<RootStackParamList, "Details">>();
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerMode: "float" });
+  }, [navigation]);
 
   return <DetailsContainer params={route.params} />;
 }

--- a/components/views/DetailsView.tsx
+++ b/components/views/DetailsView.tsx
@@ -36,7 +36,7 @@ export function DetailsView({
   if (isLoading) {
     return (
       <View style={{ flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: palette.shellBackground }}>
-        <Text style={{ color: palette.text, fontSize: 18 }}>Loading details...</Text>
+        <Text style={{ color: palette.text, fontSize: 18 }}>Loading details…</Text>
       </View>
     );
   }
@@ -51,7 +51,11 @@ export function DetailsView({
   }
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: palette.shellBackground }} contentContainerStyle={{ padding: 16, gap: 16 }}>
+    <ScrollView
+      style={{ flex: 1, minHeight: 0, backgroundColor: palette.shellBackground }}
+      contentContainerStyle={{ flexGrow: 1, padding: 16, paddingBottom: 96, gap: 16 }}
+      contentInsetAdjustmentBehavior="automatic"
+    >
       <Image
         source={imageSrc ? { uri: imageSrc } : fallbackImage}
         placeholder={fallbackImage}


### PR DESCRIPTION
Closes #59

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Keeps Details page scrolling inside the React Navigation card instead of relying on body/page overflow.
- Sizes the Details ScrollView content so long details can scroll reliably on web.
- Preserves the existing visual behavior while fixing desktop and mobile web scroll interaction.

## Changes
| File | Change |
|------|--------|
| `app/home/details/[id].tsx` | Sets Details route `headerMode` to `float` at layout time so React Navigation keeps scrolling contained in the screen/card. |
| `components/views/DetailsView.tsx` | Adds scroll container sizing/inset adjustments and bottom padding for long content. |

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/eslint 'app/home/details/[id].tsx' components/views/DetailsView.tsx`
- [x] `git diff --check -- 'app/home/details/[id].tsx' components/views/DetailsView.tsx`
- [x] `npx react-doctor@latest --verbose --diff`
- [x] Browser runtime verified Details scroll container moved from `scrollTop: 0` to `scrollTop: 420` after scroll gesture
- [x] No build/export run

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts — N/A, no scripts modified
- [x] Skills tested in at least one agent — N/A, no skills modified
- [x] Docs updated if behavior changed — N/A, bug fix only
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
