### PR TITLE
feat(results): add status-aware list redesign

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -25,6 +25,7 @@ import NotFoundScreen from "./+not-found";
 import TabNavigator from "./tabs/_layout";
 import SearchScreen from "./home/search/query";
 import DetailsScreen from "./home/details/[id]";
+import EpisodeListScreen from "./home/details/episodes";
 import type { RootStackParamList } from "./navigation/types";
 
 interface ToastInfoProps {
@@ -101,7 +102,7 @@ function handleBackPress(navigation: StackNavigationProp<RootStackParamList>): (
 }
 
 const linking: LinkingOptions<RootStackParamList> = {
-  prefixes: ['http://localhost:8081', 'exp://localhost:8081'],
+  prefixes: ['http://localhost:8081', 'exp://localhost:8081', 'https://goi17.github.io/VibeVault'],
   config: {
     screens: {
       Tabs: {
@@ -143,6 +144,29 @@ const linking: LinkingOptions<RootStackParamList> = {
             Array.isArray(value)
               ? value.map((entry) => String(entry ?? '').trim()).filter(Boolean).join(', ')
               : String(value ?? ''),
+          seasons: (value: unknown) => {
+            try {
+              return JSON.stringify(value);
+            } catch {
+              return '';
+            }
+          },
+        },
+      },
+      EpisodeList: {
+        path: 'details/:id/episodes',
+        parse: {
+          seasons: (value: string) => {
+            try {
+              const parsed: unknown = JSON.parse(value);
+              const seasonsResult = SeasonSchema.array().safeParse(parsed);
+              return seasonsResult.success ? seasonsResult.data : undefined;
+            } catch {
+              return undefined;
+            }
+          },
+        },
+        stringify: {
           seasons: (value: unknown) => {
             try {
               return JSON.stringify(value);
@@ -202,6 +226,30 @@ function RootNavigator(): ReactElement {
             component={DetailsScreen}
             options={({ navigation, route }) => ({
               title: route.params.title ?? "Details",
+              headerStyle: {
+                backgroundColor: palette.shellBackground,
+                borderBottomColor: palette.shellBorder,
+                borderBottomWidth: 1,
+                elevation: 0,
+                shadowOpacity: 0,
+              },
+              headerShadowVisible: false,
+              headerTintColor: palette.text,
+              headerLeft: () => (
+                <LeftHeaderContent
+                  showBackButton
+                  onBackPress={handleBackPress(navigation)}
+                  tintColor={palette.text}
+                  backgroundColor={palette.shellBackground}
+                />
+              ),
+            })}
+          />
+          <Stack.Screen
+            name="EpisodeList"
+            component={EpisodeListScreen}
+            options={({ navigation, route }) => ({
+              title: route.params.title ?? "Episodes",
               headerStyle: {
                 backgroundColor: palette.shellBackground,
                 borderBottomColor: palette.shellBorder,

--- a/app/home/details/episodes.tsx
+++ b/app/home/details/episodes.tsx
@@ -1,0 +1,11 @@
+import { useRoute, type RouteProp } from "@react-navigation/native";
+import type { ReactElement } from "react";
+
+import type { RootStackParamList } from "@/app/navigation/types";
+import { EpisodeListContainer } from "@/containers/EpisodeListContainer";
+
+export default function EpisodeListScreen(): ReactElement {
+  const route = useRoute<RouteProp<RootStackParamList, "EpisodeList">>();
+
+  return <EpisodeListContainer params={route.params} />;
+}

--- a/app/navigation/types.ts
+++ b/app/navigation/types.ts
@@ -22,5 +22,10 @@ export type RootStackParamList = {
     seasons?: Season[];
     source?: FavoriteSource;
   };
+  EpisodeList: {
+    id: string;
+    title?: string;
+    seasons?: Season[];
+  };
   NotFound: undefined;
 };

--- a/components/Masonry.tsx
+++ b/components/Masonry.tsx
@@ -20,6 +20,9 @@ export interface MasonryItemData {
   whereToWatch?: string[];
   seasons?: Season[];
   source?: FavoriteSource;
+  watchStatus?: "favorite" | "watched" | "watching" | "not-started";
+  progressLabel?: string;
+  progressPercent?: number;
 }
 
 interface MasonryListProps {
@@ -98,6 +101,7 @@ export default function MasonryList({
         </Pressable>
       )}
       <FlashList<MasonryItemData>
+        key={`${effectiveView}-${numColumns}`}
         numColumns={numColumns}
         style={{ flex: 1, minHeight: 0 }}
         contentContainerStyle={{

--- a/components/MasonryItem.tsx
+++ b/components/MasonryItem.tsx
@@ -1,4 +1,4 @@
-import { View, Text, StyleSheet } from "react-native";
+import { Pressable, Share, View, Text, StyleSheet } from "react-native";
 import { Image, type ImageProps } from "expo-image";
 import DoublePress from "./DoublePressTouchable";
 import { IconSymbol } from "@/components/ui/IconSymbol";
@@ -23,6 +23,16 @@ interface MediaTypeBadgeProps {
   textColor: string;
 }
 
+interface StatusPillProps {
+  status: NonNullable<MasonryItemData["watchStatus"]>;
+  tintColor: string;
+  successColor: string;
+  watchingColor: string;
+  mutedTextColor: string;
+  surfaceColor: string;
+  borderColor: string;
+}
+
 /**
  * Media type badge component
  */
@@ -37,6 +47,78 @@ const MediaTypeBadge = ({ mediaType, backgroundColor, textColor }: MediaTypeBadg
     </View>
   );
 };
+
+function getStatusLabel(status: NonNullable<MasonryItemData["watchStatus"]>): string {
+  switch (status) {
+    case "favorite":
+      return "Favorite";
+    case "watched":
+      return "Watched";
+    case "watching":
+      return "Watching";
+    case "not-started":
+      return "Not Started";
+  }
+}
+
+function getStatusIcon(status: NonNullable<MasonryItemData["watchStatus"]>): "heart.fill" | "checkmark" | "arrow.up.right" | "circle" {
+  switch (status) {
+    case "favorite":
+      return "heart.fill";
+    case "watched":
+      return "checkmark";
+    case "watching":
+      return "arrow.up.right";
+    case "not-started":
+      return "circle";
+  }
+}
+
+function getStatusColor({
+  status,
+  tintColor,
+  successColor,
+  watchingColor,
+  mutedTextColor,
+}: Pick<StatusPillProps, "status" | "tintColor" | "successColor" | "watchingColor" | "mutedTextColor">): string {
+  switch (status) {
+    case "favorite":
+      return tintColor;
+    case "watched":
+      return successColor;
+    case "watching":
+      return watchingColor;
+    case "not-started":
+      return mutedTextColor;
+  }
+}
+
+function StatusPill({
+  status,
+  tintColor,
+  successColor,
+  watchingColor,
+  mutedTextColor,
+  surfaceColor,
+  borderColor,
+}: StatusPillProps): ReactElement {
+  const statusColor = getStatusColor({ status, tintColor, successColor, watchingColor, mutedTextColor });
+
+  return (
+    <View
+      style={[
+        styles.statusPill,
+        {
+          backgroundColor: status === "not-started" ? surfaceColor : `${statusColor}22`,
+          borderColor: status === "not-started" ? borderColor : `${statusColor}55`,
+        },
+      ]}
+    >
+      <IconSymbol name={getStatusIcon(status)} color={statusColor} size={14} />
+      <Text style={[styles.statusPillText, { color: statusColor }]}>{getStatusLabel(status)}</Text>
+    </View>
+  );
+}
 
 export function MasonryItem({
   item,
@@ -53,18 +135,119 @@ export function MasonryItem({
   const actionChipBackground = theme === "dark" ? "rgba(10, 12, 18, 0.78)" : "rgba(255,255,255,0.78)";
   const mediaBadgeBackground = theme === "dark" ? "rgba(10, 12, 18, 0.82)" : "rgba(255,255,255,0.82)";
 
+  const handleFavoritePress = (): void => {
+    if (isFavorite) {
+      onRemoveFavorite();
+      return;
+    }
+
+    onAddFavorite();
+  };
+
+  const handleSharePress = (): void => {
+    void Share.share({
+      title: item.title,
+      message: item.title,
+    });
+  };
+
   const overlayActions = (
       <View style={styles.actionRow}>
-      <View style={[styles.actionChip, { backgroundColor: actionChipBackground }]}>
+      <Pressable
+        onPress={handleFavoritePress}
+        accessibilityRole="button"
+        accessibilityLabel={isFavorite ? `Remove ${item.title} from favorites` : `Add ${item.title} to favorites`}
+        hitSlop={8}
+        style={[styles.actionChip, { backgroundColor: actionChipBackground }]}
+      >
         <IconSymbol
           name={isFavorite ? "heart.fill" : "heart"}
           color={isFavorite ? palette.tint : palette.text}
           size={14}
         />
-      </View>
-      <View style={[styles.actionChip, { backgroundColor: actionChipBackground }]}>
+      </Pressable>
+      <Pressable
+        onPress={handleSharePress}
+        accessibilityRole="button"
+        accessibilityLabel={`Share ${item.title}`}
+        hitSlop={8}
+        style={[styles.actionChip, { backgroundColor: actionChipBackground }]}
+      >
         <IconSymbol name="square.and.arrow.up" color={palette.text} size={14} />
+      </Pressable>
+    </View>
+  );
+
+  const listActions = (
+    <View style={styles.listActionRow}>
+      <Pressable
+        onPress={handleFavoritePress}
+        accessibilityRole="button"
+        accessibilityLabel={isFavorite ? `Remove ${item.title} from favorites` : `Add ${item.title} to favorites`}
+        hitSlop={8}
+        style={styles.listActionButton}
+      >
+        <IconSymbol
+          name={isFavorite ? "heart.fill" : "heart"}
+          color={isFavorite ? palette.tint : palette.text}
+          size={22}
+        />
+      </Pressable>
+      <Pressable
+        onPress={handleSharePress}
+        accessibilityRole="button"
+        accessibilityLabel={`Share ${item.title}`}
+        hitSlop={8}
+        style={styles.listActionButton}
+      >
+        <IconSymbol name="square.and.arrow.up" color={palette.text} size={21} />
+      </Pressable>
+    </View>
+  );
+
+  const listCard = (
+    <View style={[styles.listCard, { backgroundColor: palette.shellSurface }]}> 
+      <Image
+        placeholder={fallbackImage}
+        source={{ uri: item.imageSrc }}
+        style={styles.listImage}
+      />
+      <View style={styles.listTextBlock}>
+        <Text
+          role="heading"
+          style={[styles.titleText, { color: palette.text }]}
+          numberOfLines={2}
+        >
+          {item.title}
+        </Text>
+        {item.mediaType && (
+          <Text style={[styles.subtitleText, { color: palette.shellMutedText }]}> 
+            {item.mediaType === "movie" ? "Movie" : "Series"}
+          </Text>
+        )}
+        {item.watchStatus ? (
+          <StatusPill
+            status={item.watchStatus}
+            tintColor={palette.tint}
+            successColor="#7CFF4E"
+            watchingColor="#3B82F6"
+            mutedTextColor={palette.shellMutedText}
+            surfaceColor={palette.shellBackground}
+            borderColor={palette.shellBorder}
+          />
+        ) : null}
+        {typeof item.progressPercent === "number" ? (
+          <View style={styles.progressBlock}>
+            <View style={[styles.progressTrack, { backgroundColor: palette.shellBorder }]}> 
+              <View style={[styles.progressFill, { width: `${item.progressPercent}%`, backgroundColor: "#3B82F6" }]} />
+            </View>
+            {item.progressLabel ? (
+              <Text style={[styles.progressText, { color: palette.shellMutedText }]}>{item.progressLabel}</Text>
+            ) : null}
+          </View>
+        ) : null}
       </View>
+      {listActions}
     </View>
   );
 
@@ -72,32 +255,7 @@ export function MasonryItem({
   if (isFavorite && view === "list") {
     return (
       <DoublePress onDoublePress={onRemoveFavorite} onSinglePress={onOpenDetails} action="remove">
-        <View style={[styles.listCard, { backgroundColor: palette.shellSurface }]}> 
-          {overlayActions}
-          <Image
-            placeholder={fallbackImage}
-            source={{ uri: item.imageSrc }}
-            style={styles.listImage}
-          />
-          <View style={styles.listTextBlock}>
-            <Text
-              role="heading"
-              style={[styles.titleText, { color: palette.text }]}
-            >
-              {item.title}
-            </Text>
-            {item.mediaType && (
-              <Text style={[styles.subtitleText, { color: palette.shellMutedText }]}>
-                {item.mediaType === "movie" ? "Movie" : "Series"}
-              </Text>
-            )}
-          </View>
-          <View
-            style={[styles.favoriteOverlay, { backgroundColor: palette.shellOverlay }]}
-          >
-            <Text style={{ color: palette.shellFabForeground }}>Marked as favorite</Text>
-          </View>
-        </View>
+        {listCard}
       </DoublePress>
     );
   }
@@ -106,27 +264,7 @@ export function MasonryItem({
   if (view === "list") {
     return (
       <DoublePress onDoublePress={onAddFavorite} onSinglePress={onOpenDetails} action="add">
-        <View style={[styles.listCard, { backgroundColor: palette.shellSurface }]}>
-          {overlayActions}
-          <Image
-            placeholder={fallbackImage}
-            source={{ uri: item.imageSrc }}
-            style={styles.listImage}
-          />
-          <View style={styles.listTextBlock}>
-            <Text
-              role="heading"
-              style={[styles.titleText, { color: palette.text }]}
-            >
-              {item.title}
-            </Text>
-            {item.mediaType && (
-              <Text style={[styles.subtitleText, { color: palette.shellMutedText }]}>
-                {item.mediaType === "movie" ? "Movie" : "Series"}
-              </Text>
-            )}
-          </View>
-        </View>
+        {listCard}
       </DoublePress>
     );
   }
@@ -252,22 +390,24 @@ const styles = StyleSheet.create({
     display: "flex",
     width: "100%",
     flexDirection: "row",
-    marginBottom: 18,
-    padding: 8,
-    alignItems: "center",
-    borderRadius: 22,
-    gap: 10,
+    marginBottom: 10,
+    padding: 10,
+    alignItems: "flex-start",
+    borderRadius: 18,
+    gap: 12,
     overflow: "hidden",
   },
   listImage: {
-    aspectRatio: 1,
-    height: 84,
-    width: 84,
-    borderRadius: 14,
+    height: 96,
+    width: 76,
+    borderRadius: 12,
   },
   listTextBlock: {
     flex: 1,
-    gap: 4,
+    minWidth: 0,
+    gap: 5,
+    paddingRight: 8,
+    paddingTop: 4,
   },
   titleText: {
     fontSize: 15,
@@ -278,6 +418,52 @@ const styles = StyleSheet.create({
   subtitleText: {
     fontSize: 12.5,
     lineHeight: 15,
+    fontWeight: "500",
+  },
+  listActionRow: {
+    flexDirection: "row",
+    gap: 12,
+    paddingTop: 4,
+  },
+  listActionButton: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  statusPill: {
+    alignSelf: "flex-start",
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    gap: 3,
+  },
+  statusPillText: {
+    fontSize: 12,
+    lineHeight: 14,
+    fontWeight: "600",
+  },
+  progressBlock: {
+    width: "100%",
+    gap: 4,
+    paddingTop: 2,
+  },
+  progressTrack: {
+    height: 5,
+    width: "100%",
+    borderRadius: 999,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: 999,
+  },
+  progressText: {
+    fontSize: 11,
+    lineHeight: 13,
     fontWeight: "500",
   },
   favoriteOverlay: {

--- a/components/views/DetailsView.tsx
+++ b/components/views/DetailsView.tsx
@@ -1,6 +1,6 @@
 import { Image } from "expo-image";
 import type { ReactElement } from "react";
-import { Pressable, ScrollView, Share, Text, TouchableOpacity, View } from "react-native";
+import { Pressable, ScrollView, Share, Text, View } from "react-native";
 
 import type { Season } from "@/domain/entities/Movie";
 import { useThemePreference } from "@/providers/ThemePreferenceProvider";
@@ -19,11 +19,9 @@ interface DetailsViewProps {
   isMovieWatched: boolean;
   isUpdatingMovieWatched: boolean;
   onToggleMovieWatched: () => void;
-  isEpisodeWatched: (seasonNumber: number, episodeNumber: number) => boolean;
   lastWatchedEpisodeLabel?: string;
-  isUpdatingEpisodeWatched: boolean;
-  onToggleEpisodeWatched: (seasonNumber: number, episodeNumber: number, watched: boolean) => void;
   seriesProgress: { watched: number; total: number };
+  onOpenEpisodeList: () => void;
 }
 
 function formatMetadata({
@@ -52,11 +50,9 @@ export function DetailsView({
   isMovieWatched,
   isUpdatingMovieWatched,
   onToggleMovieWatched,
-  isEpisodeWatched,
   lastWatchedEpisodeLabel,
-  isUpdatingEpisodeWatched,
-  onToggleEpisodeWatched,
   seriesProgress,
+  onOpenEpisodeList,
 }: DetailsViewProps): ReactElement {
   const { palette } = useThemePreference();
   const fallbackImage = require("../../assets/images/logo.png");
@@ -166,9 +162,11 @@ export function DetailsView({
       </View>
 
       {mediaType === "series" ? (
-        <View
+        <Pressable
+          onPress={onOpenEpisodeList}
+          accessibilityRole="button"
+          accessibilityLabel="Open episode list"
           style={{
-            borderWidth: 1,
             borderColor: palette.shellBorder,
             borderRadius: 18,
             backgroundColor: palette.shellSurface,
@@ -178,7 +176,10 @@ export function DetailsView({
         >
           <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
             <Text style={{ color: palette.text, fontSize: 18, fontWeight: "800" }}>Episodes</Text>
-            <Text style={{ color: palette.shellMutedText, fontWeight: "700" }}>{episodeProgressPercent}%</Text>
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
+              <Text style={{ color: palette.shellMutedText, fontWeight: "700" }}>{episodeProgressPercent}%</Text>
+              <Text style={{ color: palette.shellMutedText, fontWeight: "800" }}>›</Text>
+            </View>
           </View>
           <Text style={{ color: palette.text, fontSize: 15, fontWeight: "700" }}>
             {seriesProgress.watched} / {seriesProgress.total} Episodes
@@ -189,7 +190,7 @@ export function DetailsView({
           <Text style={{ color: palette.shellMutedText, fontSize: 13 }}>
             {lastWatchedEpisodeLabel ? `Last watched: ${lastWatchedEpisodeLabel}` : "No watched episodes yet"}
           </Text>
-        </View>
+        </Pressable>
       ) : null}
 
       <View style={{ gap: 8 }}>
@@ -215,80 +216,6 @@ export function DetailsView({
           {whereToWatch && whereToWatch.length > 0 ? whereToWatch.join(", ") : "Not available"}
         </Text>
       </View>
-
-      {mediaType === "series" && (
-        <View style={{ gap: 10 }}>
-          <Text style={{ color: palette.shellMutedText, fontSize: 12, fontWeight: "700", textTransform: "uppercase" }}>
-            Seasons and episodes
-          </Text>
-          <Text style={{ color: palette.text, fontSize: 16, fontWeight: "700" }}>
-            Progress: {seriesProgress.watched}/{seriesProgress.total} watched
-          </Text>
-
-          {seasons && seasons.length > 0 ? (
-            seasons.map((season) => (
-              <View
-                key={`season-${season.seasonNumber}`}
-                style={{ backgroundColor: palette.shellSurface, borderColor: palette.shellBorder, borderWidth: 1, borderRadius: 14, padding: 12, gap: 8 }}
-              >
-                <Text style={{ color: palette.text, fontSize: 18, fontWeight: "700" }}>
-                  {season.title || `Season ${season.seasonNumber}`}
-                </Text>
-
-                {season.episodes.map((episode) => {
-                  const episodeWatched = isEpisodeWatched(season.seasonNumber, episode.episodeNumber);
-
-                  return (
-                    <TouchableOpacity
-                      key={`episode-${season.seasonNumber}-${episode.episodeNumber}`}
-                      onPress={() =>
-                        onToggleEpisodeWatched(
-                          season.seasonNumber,
-                          episode.episodeNumber,
-                          !episodeWatched
-                        )
-                      }
-                      disabled={isUpdatingEpisodeWatched}
-                      accessibilityRole="checkbox"
-                      accessibilityState={{ checked: episodeWatched, disabled: isUpdatingEpisodeWatched }}
-                      accessibilityLabel={`${episodeWatched ? "Unmark" : "Mark"} season ${season.seasonNumber} episode ${episode.episodeNumber} as watched`}
-                      style={{
-                        backgroundColor: episodeWatched ? palette.shellChipActive : palette.shellBackground,
-                        borderColor: episodeWatched ? palette.shellChipActive : palette.shellBorder,
-                        borderRadius: 10,
-                        borderWidth: 1,
-                        gap: 2,
-                        opacity: isUpdatingEpisodeWatched ? 0.6 : 1,
-                        padding: 10,
-                      }}
-                    >
-                      <Text
-                        style={{
-                          color: episodeWatched ? palette.shellChipTextActive : palette.text,
-                          fontSize: 15,
-                          fontWeight: episodeWatched ? "700" : "400",
-                        }}
-                      >
-                        {episodeWatched ? "✓ " : ""}E{episode.episodeNumber}. {episode.title}
-                      </Text>
-                      <Text
-                        style={{
-                          color: episodeWatched ? palette.shellChipTextActive : palette.shellMutedText,
-                          fontSize: 13,
-                        }}
-                      >
-                        Release: {episode.releaseDate || "Not available"}
-                      </Text>
-                    </TouchableOpacity>
-                  );
-                })}
-              </View>
-            ))
-          ) : (
-            <Text style={{ color: palette.text, fontSize: 16 }}>No seasons available</Text>
-          )}
-        </View>
-      )}
     </ScrollView>
   );
 }

--- a/components/views/DetailsView.tsx
+++ b/components/views/DetailsView.tsx
@@ -1,9 +1,8 @@
 import { Image } from "expo-image";
 import type { ReactElement } from "react";
-import { ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { Pressable, ScrollView, Share, Text, TouchableOpacity, View } from "react-native";
 
 import type { Season } from "@/domain/entities/Movie";
-import { createEpisodeWatchedKey } from "@/domain/entities/WatchedProgress";
 import { useThemePreference } from "@/providers/ThemePreferenceProvider";
 
 interface DetailsViewProps {
@@ -20,10 +19,23 @@ interface DetailsViewProps {
   isMovieWatched: boolean;
   isUpdatingMovieWatched: boolean;
   onToggleMovieWatched: () => void;
-  watchedEpisodeKeys: ReadonlySet<string>;
+  isEpisodeWatched: (seasonNumber: number, episodeNumber: number) => boolean;
+  lastWatchedEpisodeLabel?: string;
   isUpdatingEpisodeWatched: boolean;
   onToggleEpisodeWatched: (seasonNumber: number, episodeNumber: number, watched: boolean) => void;
   seriesProgress: { watched: number; total: number };
+}
+
+function formatMetadata({
+  releaseDate,
+  seasons,
+  mediaType,
+}: Pick<DetailsViewProps, "releaseDate" | "seasons" | "mediaType">): string {
+  const year = releaseDate?.slice(0, 4);
+  const seasonCount = seasons?.length;
+  const seasonLabel = mediaType === "series" && seasonCount ? `${seasonCount} ${seasonCount === 1 ? "Season" : "Seasons"}` : null;
+
+  return [year, seasonLabel].filter(Boolean).join(" · ") || (mediaType === "series" ? "Series" : "Movie");
 }
 
 export function DetailsView({
@@ -40,13 +52,20 @@ export function DetailsView({
   isMovieWatched,
   isUpdatingMovieWatched,
   onToggleMovieWatched,
-  watchedEpisodeKeys,
+  isEpisodeWatched,
+  lastWatchedEpisodeLabel,
   isUpdatingEpisodeWatched,
   onToggleEpisodeWatched,
   seriesProgress,
 }: DetailsViewProps): ReactElement {
   const { palette } = useThemePreference();
   const fallbackImage = require("../../assets/images/logo.png");
+  const metadata = formatMetadata({ releaseDate, seasons, mediaType });
+  const episodeProgressPercent = seriesProgress.total > 0 ? Math.round((seriesProgress.watched / seriesProgress.total) * 100) : 0;
+
+  const handleShare = (): void => {
+    void Share.share({ title, message: title });
+  };
 
   if (isLoading) {
     return (
@@ -71,40 +90,106 @@ export function DetailsView({
       contentContainerStyle={{ flexGrow: 1, padding: 16, paddingBottom: 96, gap: 16 }}
       contentInsetAdjustmentBehavior="automatic"
     >
-      <Image
-        source={imageSrc ? { uri: imageSrc } : fallbackImage}
-        placeholder={fallbackImage}
-        style={{ width: "100%", height: 260, borderRadius: 18 }}
-      />
-
-      {mediaType === "movie" ? (
-        <TouchableOpacity
-          onPress={onToggleMovieWatched}
-          disabled={isUpdatingMovieWatched}
-          accessibilityRole="button"
-          accessibilityState={{ selected: isMovieWatched, disabled: isUpdatingMovieWatched }}
-          accessibilityLabel={isMovieWatched ? "Mark movie as unwatched" : "Mark movie as watched"}
+      <View style={{ borderRadius: 24, overflow: "hidden", backgroundColor: palette.shellSurface }}>
+        <Image
+          source={imageSrc ? { uri: imageSrc } : fallbackImage}
+          placeholder={fallbackImage}
+          style={{ width: "100%", height: 260 }}
+        />
+        <View
           style={{
-            alignSelf: "flex-start",
-            backgroundColor: isMovieWatched ? palette.shellChipActive : palette.shellSurface,
-            borderColor: isMovieWatched ? palette.shellChipActive : palette.shellBorder,
-            borderRadius: 18,
+            marginTop: -54,
+            marginHorizontal: 14,
+            marginBottom: 14,
+            borderRadius: 20,
             borderWidth: 1,
-            opacity: isUpdatingMovieWatched ? 0.6 : 1,
-            paddingHorizontal: 16,
-            paddingVertical: 10,
+            borderColor: palette.shellBorder,
+            backgroundColor: palette.shellSurface,
+            padding: 14,
+            gap: 12,
           }}
         >
-          <Text
-            style={{
-              color: isMovieWatched ? palette.shellChipTextActive : palette.text,
-              fontSize: 15,
-              fontWeight: "700",
-            }}
-          >
-            {isMovieWatched ? "Watched" : "Mark as watched"}
+          <View style={{ flexDirection: "row", gap: 12, alignItems: "flex-end" }}>
+            <Image
+              source={imageSrc ? { uri: imageSrc } : fallbackImage}
+              placeholder={fallbackImage}
+              style={{ width: 76, height: 96, borderRadius: 12 }}
+            />
+            <View style={{ flex: 1, minWidth: 0, gap: 6 }}>
+              <Text style={{ color: palette.text, fontSize: 26, lineHeight: 30, fontWeight: "800" }} numberOfLines={2}>
+                {title}
+              </Text>
+              <Text style={{ color: palette.shellMutedText, fontSize: 14, fontWeight: "600" }}>{metadata}</Text>
+            </View>
+          </View>
+
+          <View style={{ flexDirection: "row", gap: 8 }}>
+            <Pressable
+              onPress={mediaType === "movie" ? onToggleMovieWatched : undefined}
+              disabled={mediaType !== "movie" || isUpdatingMovieWatched}
+              accessibilityRole="button"
+              accessibilityState={{ selected: mediaType === "movie" ? isMovieWatched : false, disabled: mediaType !== "movie" || isUpdatingMovieWatched }}
+              accessibilityLabel={mediaType === "movie" ? (isMovieWatched ? "Mark movie as unwatched" : "Mark movie as watched") : "Favorite status"}
+              style={{
+                flex: 1,
+                minHeight: 44,
+                borderRadius: 12,
+                borderWidth: 1,
+                borderColor: palette.shellBorder,
+                alignItems: "center",
+                justifyContent: "center",
+                opacity: isUpdatingMovieWatched ? 0.6 : 1,
+              }}
+            >
+              <Text style={{ color: palette.text, fontWeight: "700" }}>
+                {mediaType === "movie" ? (isMovieWatched ? "Watched" : "Mark watched") : "Favorite"}
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={handleShare}
+              accessibilityRole="button"
+              accessibilityLabel={`Share ${title}`}
+              style={{
+                flex: 1,
+                minHeight: 44,
+                borderRadius: 12,
+                borderWidth: 1,
+                borderColor: palette.shellBorder,
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Text style={{ color: palette.text, fontWeight: "700" }}>Share</Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+
+      {mediaType === "series" ? (
+        <View
+          style={{
+            borderWidth: 1,
+            borderColor: palette.shellBorder,
+            borderRadius: 18,
+            backgroundColor: palette.shellSurface,
+            padding: 14,
+            gap: 10,
+          }}
+        >
+          <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
+            <Text style={{ color: palette.text, fontSize: 18, fontWeight: "800" }}>Episodes</Text>
+            <Text style={{ color: palette.shellMutedText, fontWeight: "700" }}>{episodeProgressPercent}%</Text>
+          </View>
+          <Text style={{ color: palette.text, fontSize: 15, fontWeight: "700" }}>
+            {seriesProgress.watched} / {seriesProgress.total} Episodes
           </Text>
-        </TouchableOpacity>
+          <View style={{ height: 6, borderRadius: 999, overflow: "hidden", backgroundColor: palette.shellBorder }}>
+            <View style={{ height: "100%", width: `${episodeProgressPercent}%`, backgroundColor: "#3B82F6" }} />
+          </View>
+          <Text style={{ color: palette.shellMutedText, fontSize: 13 }}>
+            {lastWatchedEpisodeLabel ? `Last watched: ${lastWatchedEpisodeLabel}` : "No watched episodes yet"}
+          </Text>
+        </View>
       ) : null}
 
       <View style={{ gap: 8 }}>
@@ -151,8 +236,7 @@ export function DetailsView({
                 </Text>
 
                 {season.episodes.map((episode) => {
-                  const episodeKey = createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber);
-                  const isEpisodeWatched = watchedEpisodeKeys.has(episodeKey);
+                  const episodeWatched = isEpisodeWatched(season.seasonNumber, episode.episodeNumber);
 
                   return (
                     <TouchableOpacity
@@ -161,16 +245,16 @@ export function DetailsView({
                         onToggleEpisodeWatched(
                           season.seasonNumber,
                           episode.episodeNumber,
-                          !isEpisodeWatched
+                          !episodeWatched
                         )
                       }
                       disabled={isUpdatingEpisodeWatched}
                       accessibilityRole="checkbox"
-                      accessibilityState={{ checked: isEpisodeWatched, disabled: isUpdatingEpisodeWatched }}
-                      accessibilityLabel={`${isEpisodeWatched ? "Unmark" : "Mark"} season ${season.seasonNumber} episode ${episode.episodeNumber} as watched`}
+                      accessibilityState={{ checked: episodeWatched, disabled: isUpdatingEpisodeWatched }}
+                      accessibilityLabel={`${episodeWatched ? "Unmark" : "Mark"} season ${season.seasonNumber} episode ${episode.episodeNumber} as watched`}
                       style={{
-                        backgroundColor: isEpisodeWatched ? palette.shellChipActive : palette.shellBackground,
-                        borderColor: isEpisodeWatched ? palette.shellChipActive : palette.shellBorder,
+                        backgroundColor: episodeWatched ? palette.shellChipActive : palette.shellBackground,
+                        borderColor: episodeWatched ? palette.shellChipActive : palette.shellBorder,
                         borderRadius: 10,
                         borderWidth: 1,
                         gap: 2,
@@ -180,16 +264,16 @@ export function DetailsView({
                     >
                       <Text
                         style={{
-                          color: isEpisodeWatched ? palette.shellChipTextActive : palette.text,
+                          color: episodeWatched ? palette.shellChipTextActive : palette.text,
                           fontSize: 15,
-                          fontWeight: isEpisodeWatched ? "700" : "400",
+                          fontWeight: episodeWatched ? "700" : "400",
                         }}
                       >
-                        {isEpisodeWatched ? "✓ " : ""}E{episode.episodeNumber}. {episode.title}
+                        {episodeWatched ? "✓ " : ""}E{episode.episodeNumber}. {episode.title}
                       </Text>
                       <Text
                         style={{
-                          color: isEpisodeWatched ? palette.shellChipTextActive : palette.shellMutedText,
+                          color: episodeWatched ? palette.shellChipTextActive : palette.shellMutedText,
                           fontSize: 13,
                         }}
                       >

--- a/components/views/EpisodeListView.tsx
+++ b/components/views/EpisodeListView.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState, type ReactElement } from "react";
+import { ScrollView, Text, TouchableOpacity, View } from "react-native";
+
+import { IconSymbol } from "@/components/ui/IconSymbol";
+import { useThemePreference } from "@/providers/ThemePreferenceProvider";
+
+export interface EpisodeListEpisodeViewModel {
+  key: string;
+  episodeNumber: number;
+  title: string;
+  releaseDate?: string;
+  isWatched: boolean;
+  isCurrent: boolean;
+}
+
+export interface EpisodeListSeasonViewModel {
+  seasonNumber: number;
+  label: string;
+  watchedCount: number;
+  progressPercent: number;
+  episodes: EpisodeListEpisodeViewModel[];
+}
+
+interface EpisodeListViewProps {
+  title: string;
+  seasons: EpisodeListSeasonViewModel[];
+  isUpdatingEpisodeWatched: boolean;
+  onToggleEpisodeWatched: (seasonNumber: number, episodeNumber: number, watched: boolean) => void;
+}
+
+export function EpisodeListView({
+  title,
+  seasons,
+  isUpdatingEpisodeWatched,
+  onToggleEpisodeWatched,
+}: EpisodeListViewProps): ReactElement {
+  const { palette } = useThemePreference();
+  const [selectedSeasonNumber, setSelectedSeasonNumber] = useState(seasons[0]?.seasonNumber ?? 0);
+  const selectedSeason = seasons.find((season) => season.seasonNumber === selectedSeasonNumber) ?? seasons[0];
+  const seasonEpisodes = useMemo(() => selectedSeason?.episodes ?? [], [selectedSeason]);
+
+  if (!selectedSeason) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: palette.shellBackground, padding: 20 }}>
+        <Text style={{ color: palette.text, fontSize: 18, fontWeight: "700" }}>No episodes available</Text>
+        <Text style={{ color: palette.shellMutedText, marginTop: 8, textAlign: "center" }}>
+          This series does not include season information yet.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1, minHeight: 0, backgroundColor: palette.shellBackground }}>
+      <ScrollView
+        style={{ flex: 1, minHeight: 0 }}
+        contentContainerStyle={{ flexGrow: 1, padding: 16, paddingBottom: 96, gap: 14 }}
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <View style={{ gap: 10 }}>
+          <Text style={{ color: palette.text, fontSize: 22, lineHeight: 26, fontWeight: "800" }}>{title}</Text>
+          <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
+            {seasons.map((season) => {
+              const isSelected = season.seasonNumber === selectedSeason?.seasonNumber;
+
+              return (
+                <TouchableOpacity
+                  key={season.seasonNumber}
+                  onPress={() => setSelectedSeasonNumber(season.seasonNumber)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: isSelected }}
+                  accessibilityLabel={`Show ${season.label}`}
+                  style={{
+                    borderRadius: 14,
+                    borderWidth: 1,
+                    borderColor: isSelected ? palette.shellChipActive : palette.shellBorder,
+                    backgroundColor: isSelected ? palette.shellChipActive : palette.shellSurface,
+                    paddingHorizontal: 12,
+                    paddingVertical: 8,
+                  }}
+                >
+                  <Text style={{ color: isSelected ? palette.shellChipTextActive : palette.text, fontWeight: "700" }}>
+                    {season.label}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+          <View style={{ gap: 6 }}>
+            <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
+              <Text style={{ color: palette.text, fontWeight: "700" }}>
+                {selectedSeason.watchedCount} / {seasonEpisodes.length} Episodes
+              </Text>
+              <Text style={{ color: palette.shellMutedText, fontWeight: "700" }}>{selectedSeason.progressPercent}%</Text>
+            </View>
+            <View style={{ height: 6, borderRadius: 999, overflow: "hidden", backgroundColor: palette.shellBorder }}>
+              <View style={{ height: "100%", width: `${selectedSeason.progressPercent}%`, backgroundColor: "#3B82F6" }} />
+            </View>
+          </View>
+        </View>
+
+        <View style={{ gap: 10 }}>
+          {seasonEpisodes.map((episode) => {
+            return (
+              <TouchableOpacity
+                key={episode.key}
+                onPress={() => onToggleEpisodeWatched(selectedSeason.seasonNumber, episode.episodeNumber, !episode.isWatched)}
+                disabled={isUpdatingEpisodeWatched}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: episode.isWatched, disabled: isUpdatingEpisodeWatched }}
+                accessibilityLabel={`${episode.isWatched ? "Unmark" : "Mark"} episode ${episode.episodeNumber} as watched`}
+                style={{
+                  minHeight: 64,
+                  borderRadius: 14,
+                  borderWidth: 1,
+                  borderColor: episode.isCurrent ? "#3B82F6" : palette.shellBorder,
+                  backgroundColor: palette.shellSurface,
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: 12,
+                  opacity: isUpdatingEpisodeWatched ? 0.7 : 1,
+                }}
+              >
+                <IconSymbol
+                  name={episode.isWatched ? "checkmark" : episode.isCurrent ? "arrow.up.right" : "circle"}
+                  color={episode.isWatched ? "#7CFF4E" : episode.isCurrent ? "#3B82F6" : palette.shellMutedText}
+                  size={24}
+                />
+                <View style={{ flex: 1, minWidth: 0, gap: 3 }}>
+                  <Text style={{ color: palette.text, fontSize: 15, fontWeight: "700" }} numberOfLines={1}>
+                    {episode.episodeNumber}. {episode.title}
+                  </Text>
+                  <Text style={{ color: palette.shellMutedText, fontSize: 13 }} numberOfLines={1}>
+                    {episode.releaseDate || "Release date unavailable"}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/containers/DetailsContainer.tsx
+++ b/containers/DetailsContainer.tsx
@@ -141,6 +141,30 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
     );
   }, [watchedEpisodeStatuses]);
 
+  const lastWatchedEpisodeLabel = useMemo(() => {
+    const watchedEpisodesByKey = new Map(
+      watchedEpisodeStatuses
+        .filter((episode) => episode.watched && episode.watchedAt)
+        .map((episode) => [createEpisodeWatchedKey(episode.seasonNumber, episode.episodeNumber), episode.watchedAt])
+    );
+
+    const watchedEpisodes =
+      seasons?.flatMap((season) =>
+        season.episodes.flatMap((episode) => {
+          const watchedAt = watchedEpisodesByKey.get(
+            createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber)
+          );
+
+          return watchedAt ? [{ seasonNumber: season.seasonNumber, episode, watchedAt }] : [];
+        })
+      ) ?? [];
+
+    const lastWatched = watchedEpisodes.sort((left, right) => left.watchedAt.localeCompare(right.watchedAt)).at(-1);
+    return lastWatched
+      ? `S${lastWatched.seasonNumber}E${lastWatched.episode.episodeNumber} · ${lastWatched.episode.title}`
+      : undefined;
+  }, [seasons, watchedEpisodeStatuses]);
+
   const seriesProgress = useMemo(() => {
     let watched = 0;
     let total = 0;
@@ -216,7 +240,10 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
       isMovieWatched={Boolean(watchedMovieStatus?.watched)}
       isUpdatingMovieWatched={toggleMovieWatchedMutation.isPending}
       onToggleMovieWatched={() => toggleMovieWatchedMutation.mutate(!watchedMovieStatus?.watched)}
-      watchedEpisodeKeys={watchedEpisodeKeys}
+      isEpisodeWatched={(seasonNumber, episodeNumber) =>
+        watchedEpisodeKeys.has(createEpisodeWatchedKey(seasonNumber, episodeNumber))
+      }
+      lastWatchedEpisodeLabel={lastWatchedEpisodeLabel}
       isUpdatingEpisodeWatched={toggleEpisodeWatchedMutation.isPending}
       onToggleEpisodeWatched={(seasonNumber, episodeNumber, watched) =>
         toggleEpisodeWatchedMutation.mutate({ seasonNumber, episodeNumber, watched })

--- a/containers/DetailsContainer.tsx
+++ b/containers/DetailsContainer.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigation, type NavigationProp } from "@react-navigation/native";
 import { useMemo, type ReactElement } from "react";
 import { z } from "zod";
 
@@ -6,17 +7,11 @@ import { DetailsView } from "@/components/views/DetailsView";
 import type { RootStackParamList } from "@/app/navigation/types";
 import { useRepositories } from "@/providers/RepositoryProvider";
 import { inferMovieMediaType, SeasonSchema } from "@/domain/entities/Movie";
-import { createEpisodeWatchedKey, type WatchedEpisodeInput } from "@/domain/entities/WatchedProgress";
+import { createEpisodeWatchedKey } from "@/domain/entities/WatchedProgress";
 import { queryOptions } from "@/constants/query";
 
 interface DetailsContainerProps {
   params: RootStackParamList["Details"];
-}
-
-interface EpisodeToggleInput {
-  seasonNumber: number;
-  episodeNumber: number;
-  watched: boolean;
 }
 
 function normalizeStringList(value: unknown): string[] | undefined {
@@ -62,6 +57,7 @@ function normalizeSeasons(
 }
 
 export function DetailsContainer({ params }: DetailsContainerProps): ReactElement {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const { movieRepository, favoriteRepository, watchedProgressRepository } = useRepositories();
   const queryClient = useQueryClient();
   const isManualFavorite = params.source === "manual" || params.id.startsWith("custom-");
@@ -94,21 +90,6 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
     mutationFn: (watched: boolean) => watchedProgressRepository.setMovieWatched(params.id, watched),
     onSuccess: () => {
       void queryClient.invalidateQueries(queryOptions.watchedProgress.movie(params.id));
-      void queryClient.invalidateQueries({ queryKey: ["watched-progress", "summary"] });
-    },
-  });
-
-  const toggleEpisodeWatchedMutation = useMutation({
-    mutationFn: (input: EpisodeToggleInput) => {
-      const watchedInput: WatchedEpisodeInput = {
-        mediaId: params.id,
-        ...input,
-      };
-
-      return watchedProgressRepository.setEpisodeWatched(watchedInput);
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries(queryOptions.watchedProgress.episodes(params.id));
       void queryClient.invalidateQueries({ queryKey: ["watched-progress", "summary"] });
     },
   });
@@ -240,15 +221,15 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
       isMovieWatched={Boolean(watchedMovieStatus?.watched)}
       isUpdatingMovieWatched={toggleMovieWatchedMutation.isPending}
       onToggleMovieWatched={() => toggleMovieWatchedMutation.mutate(!watchedMovieStatus?.watched)}
-      isEpisodeWatched={(seasonNumber, episodeNumber) =>
-        watchedEpisodeKeys.has(createEpisodeWatchedKey(seasonNumber, episodeNumber))
-      }
       lastWatchedEpisodeLabel={lastWatchedEpisodeLabel}
-      isUpdatingEpisodeWatched={toggleEpisodeWatchedMutation.isPending}
-      onToggleEpisodeWatched={(seasonNumber, episodeNumber, watched) =>
-        toggleEpisodeWatchedMutation.mutate({ seasonNumber, episodeNumber, watched })
-      }
       seriesProgress={seriesProgress}
+      onOpenEpisodeList={() =>
+        navigation.navigate("EpisodeList", {
+          id: params.id,
+          title,
+          ...(seasons ? { seasons } : {}),
+        })
+      }
     />
   );
 }

--- a/containers/DetailsContainer.tsx
+++ b/containers/DetailsContainer.tsx
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { DetailsView } from "@/components/views/DetailsView";
 import type { RootStackParamList } from "@/app/navigation/types";
 import { useRepositories } from "@/providers/RepositoryProvider";
-import { SeasonSchema } from "@/domain/entities/Movie";
+import { inferMovieMediaType, SeasonSchema } from "@/domain/entities/Movie";
 import { createEpisodeWatchedKey, type WatchedEpisodeInput } from "@/domain/entities/WatchedProgress";
 import { queryOptions } from "@/constants/query";
 
@@ -94,6 +94,7 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
     mutationFn: (watched: boolean) => watchedProgressRepository.setMovieWatched(params.id, watched),
     onSuccess: () => {
       void queryClient.invalidateQueries(queryOptions.watchedProgress.movie(params.id));
+      void queryClient.invalidateQueries({ queryKey: ["watched-progress", "summary"] });
     },
   });
 
@@ -108,17 +109,13 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
     },
     onSuccess: () => {
       void queryClient.invalidateQueries(queryOptions.watchedProgress.episodes(params.id));
+      void queryClient.invalidateQueries({ queryKey: ["watched-progress", "summary"] });
     },
   });
 
   const missingDetails = !isManualFavorite && !isLoading && !error && data === null;
 
-  const resolvedType = data?.type?.toLowerCase();
-  const mediaType = resolvedType
-    ? resolvedType.includes("tv") || resolvedType.includes("series")
-      ? "series"
-      : "movie"
-    : params.mediaType || "movie";
+  const mediaType = data?.type ? inferMovieMediaType(data.type) : manualDetails?.mediaType || params.mediaType || "movie";
 
   const title = data?.primaryTitle || manualDetails?.title || params.title || "Título no disponible";
   const description = data?.plot || manualDetails?.description || params.description;

--- a/containers/EpisodeListContainer.tsx
+++ b/containers/EpisodeListContainer.tsx
@@ -1,0 +1,132 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, type ReactElement } from "react";
+import { z } from "zod";
+
+import type { RootStackParamList } from "@/app/navigation/types";
+import { EpisodeListView, type EpisodeListSeasonViewModel } from "@/components/views/EpisodeListView";
+import { queryOptions } from "@/constants/query";
+import { SeasonSchema } from "@/domain/entities/Movie";
+import { createEpisodeWatchedKey, type WatchedEpisodeInput } from "@/domain/entities/WatchedProgress";
+import { useRepositories } from "@/providers/RepositoryProvider";
+
+interface EpisodeListContainerProps {
+  params: RootStackParamList["EpisodeList"];
+}
+
+interface EpisodeToggleInput {
+  seasonNumber: number;
+  episodeNumber: number;
+  watched: boolean;
+}
+
+function normalizeSeasons(value: unknown): RootStackParamList["EpisodeList"]["seasons"] {
+  const parsedValue =
+    typeof value === "string"
+      ? (() => {
+          try {
+            return JSON.parse(value) as unknown;
+          } catch {
+            return undefined;
+          }
+        })()
+      : value;
+
+  const parsedSeasons = z.array(SeasonSchema).safeParse(parsedValue);
+  return parsedSeasons.success ? parsedSeasons.data : undefined;
+}
+
+function getSeasonLabel(season: NonNullable<RootStackParamList["EpisodeList"]["seasons"]>[number]): string {
+  return season.title || `Season ${season.seasonNumber}`;
+}
+
+export function EpisodeListContainer({ params }: EpisodeListContainerProps): ReactElement {
+  const { movieRepository, watchedProgressRepository } = useRepositories();
+  const queryClient = useQueryClient();
+  const needsDetailsFallback = !params.title || !params.seasons || params.seasons.length === 0;
+  const { data: details } = useQuery({
+    queryKey: ["movies", "details", params.id],
+    queryFn: () => movieRepository.getById(params.id),
+    enabled: Boolean(params.id) && needsDetailsFallback,
+  });
+  const seasonsSource = params.seasons && params.seasons.length > 0 ? params.seasons : details?.seasons;
+  const seasons = useMemo(() => normalizeSeasons(seasonsSource) ?? [], [seasonsSource]);
+  const title = details?.primaryTitle || params.title || "Episodes";
+
+  const { data: watchedEpisodeStatuses = [] } = useQuery({
+    ...queryOptions.watchedProgress.episodes(params.id),
+    queryFn: () => watchedProgressRepository.getEpisodeStatuses(params.id),
+    enabled: Boolean(params.id),
+  });
+
+  const toggleEpisodeWatchedMutation = useMutation({
+    mutationFn: (input: EpisodeToggleInput) => {
+      const watchedInput: WatchedEpisodeInput = {
+        mediaId: params.id,
+        ...input,
+      };
+
+      return watchedProgressRepository.setEpisodeWatched(watchedInput);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries(queryOptions.watchedProgress.episodes(params.id));
+      void queryClient.invalidateQueries({ queryKey: ["watched-progress", "summary"] });
+    },
+  });
+
+  const watchedEpisodeKeys = useMemo(
+    () =>
+      new Set(
+        watchedEpisodeStatuses
+          .filter((episode) => episode.watched)
+          .map((episode) => createEpisodeWatchedKey(episode.seasonNumber, episode.episodeNumber))
+      ),
+    [watchedEpisodeStatuses]
+  );
+
+  const seasonViewModels = useMemo<EpisodeListSeasonViewModel[]>(
+    () =>
+      seasons.map((season) => {
+        const firstUnwatchedEpisode = season.episodes.find(
+          (episode) => !watchedEpisodeKeys.has(createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber))
+        );
+        const firstUnwatchedKey = firstUnwatchedEpisode
+          ? createEpisodeWatchedKey(season.seasonNumber, firstUnwatchedEpisode.episodeNumber)
+          : null;
+        const watchedCount = season.episodes.filter((episode) =>
+          watchedEpisodeKeys.has(createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber))
+        ).length;
+
+        return {
+          seasonNumber: season.seasonNumber,
+          label: getSeasonLabel(season),
+          watchedCount,
+          progressPercent: season.episodes.length > 0 ? Math.round((watchedCount / season.episodes.length) * 100) : 0,
+          episodes: season.episodes.map((episode) => {
+            const episodeKey = createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber);
+            const isWatched = watchedEpisodeKeys.has(episodeKey);
+
+            return {
+              key: episodeKey,
+              episodeNumber: episode.episodeNumber,
+              title: episode.title,
+              releaseDate: episode.releaseDate,
+              isWatched,
+              isCurrent: !isWatched && episodeKey === firstUnwatchedKey,
+            };
+          }),
+        };
+      }),
+    [seasons, watchedEpisodeKeys]
+  );
+
+  return (
+    <EpisodeListView
+      title={title}
+      seasons={seasonViewModels}
+      isUpdatingEpisodeWatched={toggleEpisodeWatchedMutation.isPending}
+      onToggleEpisodeWatched={(seasonNumber, episodeNumber, watched) =>
+        toggleEpisodeWatchedMutation.mutate({ seasonNumber, episodeNumber, watched })
+      }
+    />
+  );
+}

--- a/containers/HomeContainer.tsx
+++ b/containers/HomeContainer.tsx
@@ -5,12 +5,14 @@ import { useMemo, type ReactElement } from "react";
 import type { RootStackParamList } from "@/app/navigation/types";
 import { HomeView } from "@/components/views/HomeView";
 import { queryOptions } from "@/constants/query";
+import { inferMovieMediaType } from "@/domain/entities/Movie";
 import { useFavoriteMutations } from "@/hooks/useFavoriteMutations";
 import { useRepositories } from "@/providers/RepositoryProvider";
+import { getWatchStatusByMediaId } from "./watchStatusViewModel";
 
 export function HomeContainer(): ReactElement {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
-  const { movieRepository, favoriteRepository } = useRepositories();
+  const { movieRepository, favoriteRepository, watchedProgressRepository } = useRepositories();
   const { data, isLoading, error } = useQuery({
     ...queryOptions.movies.random,
     queryFn: () => movieRepository.getRandom(),
@@ -29,7 +31,7 @@ export function HomeContainer(): ReactElement {
         key: item.id,
         imageSrc: item.primaryImage?.url,
         title: item.primaryTitle,
-        mediaType: (item.type?.toLowerCase().includes("tv") ? "series" : "movie") as "movie" | "series",
+        mediaType: inferMovieMediaType(item.type),
         description: item.plot,
         cast: item.cast,
         releaseDate: item.releaseDate || item.startYear?.toString(),
@@ -40,12 +42,21 @@ export function HomeContainer(): ReactElement {
   );
 
   const favoriteIds = useMemo(() => new Set(favorites?.map((item) => item.id) ?? []), [favorites]);
+  const { data: watchStatusByMediaId = {} } = useQuery({
+    queryKey: ["watched-progress", "summary", movies.map((item) => item.key).sort()],
+    queryFn: () => getWatchStatusByMediaId(movies, watchedProgressRepository),
+    enabled: movies.length > 0,
+  });
+  const moviesWithWatchStatus = movies.map((item) => ({
+    ...item,
+    ...watchStatusByMediaId[item.key],
+  }));
 
   return (
     <HomeView
       isLoading={isLoading}
       errorMessage={error?.message}
-      movies={movies}
+      movies={moviesWithWatchStatus}
       favoriteIds={favoriteIds}
       onAddFavorite={(item) =>
         addFavorite({

--- a/containers/SearchContainer.tsx
+++ b/containers/SearchContainer.tsx
@@ -5,8 +5,10 @@ import { useEffect, useMemo, useState, type ReactElement } from "react";
 import type { RootStackParamList } from "@/app/navigation/types";
 import { SearchView } from "@/components/views/SearchView";
 import { queryOptions } from "@/constants/query";
+import { inferMovieMediaType } from "@/domain/entities/Movie";
 import { useFavoriteMutations } from "@/hooks/useFavoriteMutations";
 import { useRepositories } from "@/providers/RepositoryProvider";
+import { getWatchStatusByMediaId } from "./watchStatusViewModel";
 
 interface SearchContainerProps {
   query: string;
@@ -14,7 +16,7 @@ interface SearchContainerProps {
 
 export function SearchContainer({ query }: SearchContainerProps): ReactElement {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
-  const { movieRepository, favoriteRepository } = useRepositories();
+  const { movieRepository, favoriteRepository, watchedProgressRepository } = useRepositories();
   const { addFavorite, removeFavorite } = useFavoriteMutations();
   const [activeQuery, setActiveQuery] = useState(query);
   const [retryCount, setRetryCount] = useState(0);
@@ -58,13 +60,22 @@ export function SearchContainer({ query }: SearchContainerProps): ReactElement {
         key: item.id,
         imageSrc: item.primaryImage?.url,
         title: item.primaryTitle,
-        mediaType: ((item.type?.toLowerCase() ?? "").includes("tv") ? "series" : "movie") as "movie" | "series",
+        mediaType: inferMovieMediaType(item.type),
         description: item.plot,
         cast: item.cast,
         releaseDate: item.releaseDate || item.startYear?.toString(),
         whereToWatch: item.whereToWatch,
         seasons: item.seasons,
       })) || [];
+  const { data: watchStatusByMediaId = {} } = useQuery({
+    queryKey: ["watched-progress", "summary", mappedData.map((item) => item.key).sort()],
+    queryFn: () => getWatchStatusByMediaId(mappedData, watchedProgressRepository),
+    enabled: mappedData.length > 0,
+  });
+  const dataWithWatchStatus = mappedData.map((item) => ({
+    ...item,
+    ...watchStatusByMediaId[item.key],
+  }));
 
   return (
     <SearchView
@@ -74,7 +85,7 @@ export function SearchContainer({ query }: SearchContainerProps): ReactElement {
       retryCount={retryCount}
       maxRetries={3}
       isRetrying={isFetching && Boolean(error)}
-      data={mappedData}
+      data={dataWithWatchStatus}
       favoriteIds={favoriteIds}
       onRetrySearch={handleRetrySearch}
       onGoHome={() => navigation.navigate("Tabs", { screen: "Home" })}

--- a/containers/watchStatusViewModel.ts
+++ b/containers/watchStatusViewModel.ts
@@ -1,0 +1,45 @@
+import type { MasonryItemData } from "@/components/Masonry";
+import type { IWatchedProgressRepository } from "@/domain/repositories/IWatchedProgressRepository";
+
+export type WatchStatusByMediaId = Record<string, Pick<MasonryItemData, "watchStatus" | "progressLabel" | "progressPercent">>;
+
+function getSeriesEpisodeTotal(item: MasonryItemData): number {
+  return item.seasons?.reduce((total, season) => total + season.episodes.length, 0) ?? 0;
+}
+
+function createSeriesWatchStatus(watchedCount: number, totalCount: number): Pick<MasonryItemData, "watchStatus" | "progressLabel" | "progressPercent"> {
+  if (totalCount <= 0) {
+    return { watchStatus: watchedCount > 0 ? "watching" : "not-started" };
+  }
+
+  if (watchedCount <= 0) {
+    return { watchStatus: "not-started", progressLabel: `0 / ${totalCount} Episodes`, progressPercent: 0 };
+  }
+
+  const progressPercent = Math.min(100, Math.round((watchedCount / totalCount) * 100));
+
+  return {
+    watchStatus: watchedCount >= totalCount ? "watched" : "watching",
+    progressLabel: `${watchedCount} / ${totalCount} Episodes`,
+    progressPercent,
+  };
+}
+
+export async function getWatchStatusByMediaId(
+  items: MasonryItemData[],
+  watchedProgressRepository: IWatchedProgressRepository
+): Promise<WatchStatusByMediaId> {
+  const entries = await Promise.all(
+    items.map(async (item): Promise<[string, WatchStatusByMediaId[string]]> => {
+      if (item.mediaType === "series") {
+        const watchedEpisodes = await watchedProgressRepository.getEpisodeStatuses(item.key);
+        return [item.key, createSeriesWatchStatus(watchedEpisodes.filter((episode) => episode.watched).length, getSeriesEpisodeTotal(item))];
+      }
+
+      const movieStatus = await watchedProgressRepository.getMovieStatus(item.key);
+      return [item.key, { watchStatus: movieStatus?.watched ? "watched" : "not-started" }];
+    })
+  );
+
+  return Object.fromEntries(entries);
+}


### PR DESCRIPTION
Closes #64

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Redesigns Results/Home/Search list cards with compact poster-first layout.
- Wires real watched/progress status data into list cards.
- Keeps status derivation in containers/helpers and preserves component boundaries.

## Changes
| File | Change |
|------|--------|
| `components/Masonry.tsx` | Adds watch status view-model fields and remount key for column mode changes. |
| `components/MasonryItem.tsx` | Adds compact list card UI, real favorite/share actions, status pills, and progress display. |
| `containers/watchStatusViewModel.ts` | Adds shared watched/progress summary derivation. |
| `containers/HomeContainer.tsx` | Wires Home results to watched-progress summaries. |
| `containers/SearchContainer.tsx` | Wires Search results to watched-progress summaries. |
| `containers/DetailsContainer.tsx` | Invalidates summary queries after watched-progress mutations and uses domain media type inference. |

## Chain Context
Strategy: stacked-to-main

Dependency diagram:
```
main
└── 📍 PR 1: feat/results-list-status-redesign
    └── PR 2: feat/details-overview-redesign
        └── PR 3: feat/episode-list-screen
```

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/eslint components/Masonry.tsx components/MasonryItem.tsx containers/HomeContainer.tsx containers/SearchContainer.tsx containers/watchStatusViewModel.ts containers/DetailsContainer.tsx`
- [x] Fresh static review passed
- [x] React Doctor staged review passed during commit

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts / not applicable: no scripts modified
- [x] Skills tested in at least one agent / not applicable: no skills modified
- [x] Docs updated if behavior changed / not applicable: UI-only behavior
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
