### PR TITLE
feat(details): add episode list screen

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -25,6 +25,7 @@ import NotFoundScreen from "./+not-found";
 import TabNavigator from "./tabs/_layout";
 import SearchScreen from "./home/search/query";
 import DetailsScreen from "./home/details/[id]";
+import EpisodeListScreen from "./home/details/episodes";
 import type { RootStackParamList } from "./navigation/types";
 
 interface ToastInfoProps {
@@ -101,7 +102,7 @@ function handleBackPress(navigation: StackNavigationProp<RootStackParamList>): (
 }
 
 const linking: LinkingOptions<RootStackParamList> = {
-  prefixes: ['http://localhost:8081', 'exp://localhost:8081'],
+  prefixes: ['http://localhost:8081', 'exp://localhost:8081', 'https://goi17.github.io/VibeVault'],
   config: {
     screens: {
       Tabs: {
@@ -143,6 +144,29 @@ const linking: LinkingOptions<RootStackParamList> = {
             Array.isArray(value)
               ? value.map((entry) => String(entry ?? '').trim()).filter(Boolean).join(', ')
               : String(value ?? ''),
+          seasons: (value: unknown) => {
+            try {
+              return JSON.stringify(value);
+            } catch {
+              return '';
+            }
+          },
+        },
+      },
+      EpisodeList: {
+        path: 'details/:id/episodes',
+        parse: {
+          seasons: (value: string) => {
+            try {
+              const parsed: unknown = JSON.parse(value);
+              const seasonsResult = SeasonSchema.array().safeParse(parsed);
+              return seasonsResult.success ? seasonsResult.data : undefined;
+            } catch {
+              return undefined;
+            }
+          },
+        },
+        stringify: {
           seasons: (value: unknown) => {
             try {
               return JSON.stringify(value);
@@ -202,6 +226,30 @@ function RootNavigator(): ReactElement {
             component={DetailsScreen}
             options={({ navigation, route }) => ({
               title: route.params.title ?? "Details",
+              headerStyle: {
+                backgroundColor: palette.shellBackground,
+                borderBottomColor: palette.shellBorder,
+                borderBottomWidth: 1,
+                elevation: 0,
+                shadowOpacity: 0,
+              },
+              headerShadowVisible: false,
+              headerTintColor: palette.text,
+              headerLeft: () => (
+                <LeftHeaderContent
+                  showBackButton
+                  onBackPress={handleBackPress(navigation)}
+                  tintColor={palette.text}
+                  backgroundColor={palette.shellBackground}
+                />
+              ),
+            })}
+          />
+          <Stack.Screen
+            name="EpisodeList"
+            component={EpisodeListScreen}
+            options={({ navigation, route }) => ({
+              title: route.params.title ?? "Episodes",
               headerStyle: {
                 backgroundColor: palette.shellBackground,
                 borderBottomColor: palette.shellBorder,

--- a/app/home/details/episodes.tsx
+++ b/app/home/details/episodes.tsx
@@ -1,0 +1,11 @@
+import { useRoute, type RouteProp } from "@react-navigation/native";
+import type { ReactElement } from "react";
+
+import type { RootStackParamList } from "@/app/navigation/types";
+import { EpisodeListContainer } from "@/containers/EpisodeListContainer";
+
+export default function EpisodeListScreen(): ReactElement {
+  const route = useRoute<RouteProp<RootStackParamList, "EpisodeList">>();
+
+  return <EpisodeListContainer params={route.params} />;
+}

--- a/app/navigation/types.ts
+++ b/app/navigation/types.ts
@@ -22,5 +22,10 @@ export type RootStackParamList = {
     seasons?: Season[];
     source?: FavoriteSource;
   };
+  EpisodeList: {
+    id: string;
+    title?: string;
+    seasons?: Season[];
+  };
   NotFound: undefined;
 };

--- a/components/views/DetailsView.tsx
+++ b/components/views/DetailsView.tsx
@@ -1,6 +1,6 @@
 import { Image } from "expo-image";
 import type { ReactElement } from "react";
-import { Pressable, ScrollView, Share, Text, TouchableOpacity, View } from "react-native";
+import { Pressable, ScrollView, Share, Text, View } from "react-native";
 
 import type { Season } from "@/domain/entities/Movie";
 import { useThemePreference } from "@/providers/ThemePreferenceProvider";
@@ -19,11 +19,9 @@ interface DetailsViewProps {
   isMovieWatched: boolean;
   isUpdatingMovieWatched: boolean;
   onToggleMovieWatched: () => void;
-  isEpisodeWatched: (seasonNumber: number, episodeNumber: number) => boolean;
   lastWatchedEpisodeLabel?: string;
-  isUpdatingEpisodeWatched: boolean;
-  onToggleEpisodeWatched: (seasonNumber: number, episodeNumber: number, watched: boolean) => void;
   seriesProgress: { watched: number; total: number };
+  onOpenEpisodeList: () => void;
 }
 
 function formatMetadata({
@@ -52,11 +50,9 @@ export function DetailsView({
   isMovieWatched,
   isUpdatingMovieWatched,
   onToggleMovieWatched,
-  isEpisodeWatched,
   lastWatchedEpisodeLabel,
-  isUpdatingEpisodeWatched,
-  onToggleEpisodeWatched,
   seriesProgress,
+  onOpenEpisodeList,
 }: DetailsViewProps): ReactElement {
   const { palette } = useThemePreference();
   const fallbackImage = require("../../assets/images/logo.png");
@@ -166,9 +162,11 @@ export function DetailsView({
       </View>
 
       {mediaType === "series" ? (
-        <View
+        <Pressable
+          onPress={onOpenEpisodeList}
+          accessibilityRole="button"
+          accessibilityLabel="Open episode list"
           style={{
-            borderWidth: 1,
             borderColor: palette.shellBorder,
             borderRadius: 18,
             backgroundColor: palette.shellSurface,
@@ -178,7 +176,10 @@ export function DetailsView({
         >
           <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
             <Text style={{ color: palette.text, fontSize: 18, fontWeight: "800" }}>Episodes</Text>
-            <Text style={{ color: palette.shellMutedText, fontWeight: "700" }}>{episodeProgressPercent}%</Text>
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
+              <Text style={{ color: palette.shellMutedText, fontWeight: "700" }}>{episodeProgressPercent}%</Text>
+              <Text style={{ color: palette.shellMutedText, fontWeight: "800" }}>›</Text>
+            </View>
           </View>
           <Text style={{ color: palette.text, fontSize: 15, fontWeight: "700" }}>
             {seriesProgress.watched} / {seriesProgress.total} Episodes
@@ -189,7 +190,7 @@ export function DetailsView({
           <Text style={{ color: palette.shellMutedText, fontSize: 13 }}>
             {lastWatchedEpisodeLabel ? `Last watched: ${lastWatchedEpisodeLabel}` : "No watched episodes yet"}
           </Text>
-        </View>
+        </Pressable>
       ) : null}
 
       <View style={{ gap: 8 }}>
@@ -215,80 +216,6 @@ export function DetailsView({
           {whereToWatch && whereToWatch.length > 0 ? whereToWatch.join(", ") : "Not available"}
         </Text>
       </View>
-
-      {mediaType === "series" && (
-        <View style={{ gap: 10 }}>
-          <Text style={{ color: palette.shellMutedText, fontSize: 12, fontWeight: "700", textTransform: "uppercase" }}>
-            Seasons and episodes
-          </Text>
-          <Text style={{ color: palette.text, fontSize: 16, fontWeight: "700" }}>
-            Progress: {seriesProgress.watched}/{seriesProgress.total} watched
-          </Text>
-
-          {seasons && seasons.length > 0 ? (
-            seasons.map((season) => (
-              <View
-                key={`season-${season.seasonNumber}`}
-                style={{ backgroundColor: palette.shellSurface, borderColor: palette.shellBorder, borderWidth: 1, borderRadius: 14, padding: 12, gap: 8 }}
-              >
-                <Text style={{ color: palette.text, fontSize: 18, fontWeight: "700" }}>
-                  {season.title || `Season ${season.seasonNumber}`}
-                </Text>
-
-                {season.episodes.map((episode) => {
-                  const episodeWatched = isEpisodeWatched(season.seasonNumber, episode.episodeNumber);
-
-                  return (
-                    <TouchableOpacity
-                      key={`episode-${season.seasonNumber}-${episode.episodeNumber}`}
-                      onPress={() =>
-                        onToggleEpisodeWatched(
-                          season.seasonNumber,
-                          episode.episodeNumber,
-                          !episodeWatched
-                        )
-                      }
-                      disabled={isUpdatingEpisodeWatched}
-                      accessibilityRole="checkbox"
-                      accessibilityState={{ checked: episodeWatched, disabled: isUpdatingEpisodeWatched }}
-                      accessibilityLabel={`${episodeWatched ? "Unmark" : "Mark"} season ${season.seasonNumber} episode ${episode.episodeNumber} as watched`}
-                      style={{
-                        backgroundColor: episodeWatched ? palette.shellChipActive : palette.shellBackground,
-                        borderColor: episodeWatched ? palette.shellChipActive : palette.shellBorder,
-                        borderRadius: 10,
-                        borderWidth: 1,
-                        gap: 2,
-                        opacity: isUpdatingEpisodeWatched ? 0.6 : 1,
-                        padding: 10,
-                      }}
-                    >
-                      <Text
-                        style={{
-                          color: episodeWatched ? palette.shellChipTextActive : palette.text,
-                          fontSize: 15,
-                          fontWeight: episodeWatched ? "700" : "400",
-                        }}
-                      >
-                        {episodeWatched ? "✓ " : ""}E{episode.episodeNumber}. {episode.title}
-                      </Text>
-                      <Text
-                        style={{
-                          color: episodeWatched ? palette.shellChipTextActive : palette.shellMutedText,
-                          fontSize: 13,
-                        }}
-                      >
-                        Release: {episode.releaseDate || "Not available"}
-                      </Text>
-                    </TouchableOpacity>
-                  );
-                })}
-              </View>
-            ))
-          ) : (
-            <Text style={{ color: palette.text, fontSize: 16 }}>No seasons available</Text>
-          )}
-        </View>
-      )}
     </ScrollView>
   );
 }

--- a/components/views/EpisodeListView.tsx
+++ b/components/views/EpisodeListView.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState, type ReactElement } from "react";
+import { ScrollView, Text, TouchableOpacity, View } from "react-native";
+
+import { IconSymbol } from "@/components/ui/IconSymbol";
+import { useThemePreference } from "@/providers/ThemePreferenceProvider";
+
+export interface EpisodeListEpisodeViewModel {
+  key: string;
+  episodeNumber: number;
+  title: string;
+  releaseDate?: string;
+  isWatched: boolean;
+  isCurrent: boolean;
+}
+
+export interface EpisodeListSeasonViewModel {
+  seasonNumber: number;
+  label: string;
+  watchedCount: number;
+  progressPercent: number;
+  episodes: EpisodeListEpisodeViewModel[];
+}
+
+interface EpisodeListViewProps {
+  title: string;
+  seasons: EpisodeListSeasonViewModel[];
+  isUpdatingEpisodeWatched: boolean;
+  onToggleEpisodeWatched: (seasonNumber: number, episodeNumber: number, watched: boolean) => void;
+}
+
+export function EpisodeListView({
+  title,
+  seasons,
+  isUpdatingEpisodeWatched,
+  onToggleEpisodeWatched,
+}: EpisodeListViewProps): ReactElement {
+  const { palette } = useThemePreference();
+  const [selectedSeasonNumber, setSelectedSeasonNumber] = useState(seasons[0]?.seasonNumber ?? 0);
+  const selectedSeason = seasons.find((season) => season.seasonNumber === selectedSeasonNumber) ?? seasons[0];
+  const seasonEpisodes = useMemo(() => selectedSeason?.episodes ?? [], [selectedSeason]);
+
+  if (!selectedSeason) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: palette.shellBackground, padding: 20 }}>
+        <Text style={{ color: palette.text, fontSize: 18, fontWeight: "700" }}>No episodes available</Text>
+        <Text style={{ color: palette.shellMutedText, marginTop: 8, textAlign: "center" }}>
+          This series does not include season information yet.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1, minHeight: 0, backgroundColor: palette.shellBackground }}>
+      <ScrollView
+        style={{ flex: 1, minHeight: 0 }}
+        contentContainerStyle={{ flexGrow: 1, padding: 16, paddingBottom: 96, gap: 14 }}
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <View style={{ gap: 10 }}>
+          <Text style={{ color: palette.text, fontSize: 22, lineHeight: 26, fontWeight: "800" }}>{title}</Text>
+          <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
+            {seasons.map((season) => {
+              const isSelected = season.seasonNumber === selectedSeason?.seasonNumber;
+
+              return (
+                <TouchableOpacity
+                  key={season.seasonNumber}
+                  onPress={() => setSelectedSeasonNumber(season.seasonNumber)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: isSelected }}
+                  accessibilityLabel={`Show ${season.label}`}
+                  style={{
+                    borderRadius: 14,
+                    borderWidth: 1,
+                    borderColor: isSelected ? palette.shellChipActive : palette.shellBorder,
+                    backgroundColor: isSelected ? palette.shellChipActive : palette.shellSurface,
+                    paddingHorizontal: 12,
+                    paddingVertical: 8,
+                  }}
+                >
+                  <Text style={{ color: isSelected ? palette.shellChipTextActive : palette.text, fontWeight: "700" }}>
+                    {season.label}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+          <View style={{ gap: 6 }}>
+            <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
+              <Text style={{ color: palette.text, fontWeight: "700" }}>
+                {selectedSeason.watchedCount} / {seasonEpisodes.length} Episodes
+              </Text>
+              <Text style={{ color: palette.shellMutedText, fontWeight: "700" }}>{selectedSeason.progressPercent}%</Text>
+            </View>
+            <View style={{ height: 6, borderRadius: 999, overflow: "hidden", backgroundColor: palette.shellBorder }}>
+              <View style={{ height: "100%", width: `${selectedSeason.progressPercent}%`, backgroundColor: "#3B82F6" }} />
+            </View>
+          </View>
+        </View>
+
+        <View style={{ gap: 10 }}>
+          {seasonEpisodes.map((episode) => {
+            return (
+              <TouchableOpacity
+                key={episode.key}
+                onPress={() => onToggleEpisodeWatched(selectedSeason.seasonNumber, episode.episodeNumber, !episode.isWatched)}
+                disabled={isUpdatingEpisodeWatched}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: episode.isWatched, disabled: isUpdatingEpisodeWatched }}
+                accessibilityLabel={`${episode.isWatched ? "Unmark" : "Mark"} episode ${episode.episodeNumber} as watched`}
+                style={{
+                  minHeight: 64,
+                  borderRadius: 14,
+                  borderWidth: 1,
+                  borderColor: episode.isCurrent ? "#3B82F6" : palette.shellBorder,
+                  backgroundColor: palette.shellSurface,
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: 12,
+                  opacity: isUpdatingEpisodeWatched ? 0.7 : 1,
+                }}
+              >
+                <IconSymbol
+                  name={episode.isWatched ? "checkmark" : episode.isCurrent ? "arrow.up.right" : "circle"}
+                  color={episode.isWatched ? "#7CFF4E" : episode.isCurrent ? "#3B82F6" : palette.shellMutedText}
+                  size={24}
+                />
+                <View style={{ flex: 1, minWidth: 0, gap: 3 }}>
+                  <Text style={{ color: palette.text, fontSize: 15, fontWeight: "700" }} numberOfLines={1}>
+                    {episode.episodeNumber}. {episode.title}
+                  </Text>
+                  <Text style={{ color: palette.shellMutedText, fontSize: 13 }} numberOfLines={1}>
+                    {episode.releaseDate || "Release date unavailable"}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/containers/DetailsContainer.tsx
+++ b/containers/DetailsContainer.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigation, type NavigationProp } from "@react-navigation/native";
 import { useMemo, type ReactElement } from "react";
 import { z } from "zod";
 
@@ -6,17 +7,11 @@ import { DetailsView } from "@/components/views/DetailsView";
 import type { RootStackParamList } from "@/app/navigation/types";
 import { useRepositories } from "@/providers/RepositoryProvider";
 import { inferMovieMediaType, SeasonSchema } from "@/domain/entities/Movie";
-import { createEpisodeWatchedKey, type WatchedEpisodeInput } from "@/domain/entities/WatchedProgress";
+import { createEpisodeWatchedKey } from "@/domain/entities/WatchedProgress";
 import { queryOptions } from "@/constants/query";
 
 interface DetailsContainerProps {
   params: RootStackParamList["Details"];
-}
-
-interface EpisodeToggleInput {
-  seasonNumber: number;
-  episodeNumber: number;
-  watched: boolean;
 }
 
 function normalizeStringList(value: unknown): string[] | undefined {
@@ -62,6 +57,7 @@ function normalizeSeasons(
 }
 
 export function DetailsContainer({ params }: DetailsContainerProps): ReactElement {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const { movieRepository, favoriteRepository, watchedProgressRepository } = useRepositories();
   const queryClient = useQueryClient();
   const isManualFavorite = params.source === "manual" || params.id.startsWith("custom-");
@@ -94,21 +90,6 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
     mutationFn: (watched: boolean) => watchedProgressRepository.setMovieWatched(params.id, watched),
     onSuccess: () => {
       void queryClient.invalidateQueries(queryOptions.watchedProgress.movie(params.id));
-      void queryClient.invalidateQueries({ queryKey: ["watched-progress", "summary"] });
-    },
-  });
-
-  const toggleEpisodeWatchedMutation = useMutation({
-    mutationFn: (input: EpisodeToggleInput) => {
-      const watchedInput: WatchedEpisodeInput = {
-        mediaId: params.id,
-        ...input,
-      };
-
-      return watchedProgressRepository.setEpisodeWatched(watchedInput);
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries(queryOptions.watchedProgress.episodes(params.id));
       void queryClient.invalidateQueries({ queryKey: ["watched-progress", "summary"] });
     },
   });
@@ -240,15 +221,15 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
       isMovieWatched={Boolean(watchedMovieStatus?.watched)}
       isUpdatingMovieWatched={toggleMovieWatchedMutation.isPending}
       onToggleMovieWatched={() => toggleMovieWatchedMutation.mutate(!watchedMovieStatus?.watched)}
-      isEpisodeWatched={(seasonNumber, episodeNumber) =>
-        watchedEpisodeKeys.has(createEpisodeWatchedKey(seasonNumber, episodeNumber))
-      }
       lastWatchedEpisodeLabel={lastWatchedEpisodeLabel}
-      isUpdatingEpisodeWatched={toggleEpisodeWatchedMutation.isPending}
-      onToggleEpisodeWatched={(seasonNumber, episodeNumber, watched) =>
-        toggleEpisodeWatchedMutation.mutate({ seasonNumber, episodeNumber, watched })
-      }
       seriesProgress={seriesProgress}
+      onOpenEpisodeList={() =>
+        navigation.navigate("EpisodeList", {
+          id: params.id,
+          title,
+          ...(seasons ? { seasons } : {}),
+        })
+      }
     />
   );
 }

--- a/containers/EpisodeListContainer.tsx
+++ b/containers/EpisodeListContainer.tsx
@@ -1,0 +1,132 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, type ReactElement } from "react";
+import { z } from "zod";
+
+import type { RootStackParamList } from "@/app/navigation/types";
+import { EpisodeListView, type EpisodeListSeasonViewModel } from "@/components/views/EpisodeListView";
+import { queryOptions } from "@/constants/query";
+import { SeasonSchema } from "@/domain/entities/Movie";
+import { createEpisodeWatchedKey, type WatchedEpisodeInput } from "@/domain/entities/WatchedProgress";
+import { useRepositories } from "@/providers/RepositoryProvider";
+
+interface EpisodeListContainerProps {
+  params: RootStackParamList["EpisodeList"];
+}
+
+interface EpisodeToggleInput {
+  seasonNumber: number;
+  episodeNumber: number;
+  watched: boolean;
+}
+
+function normalizeSeasons(value: unknown): RootStackParamList["EpisodeList"]["seasons"] {
+  const parsedValue =
+    typeof value === "string"
+      ? (() => {
+          try {
+            return JSON.parse(value) as unknown;
+          } catch {
+            return undefined;
+          }
+        })()
+      : value;
+
+  const parsedSeasons = z.array(SeasonSchema).safeParse(parsedValue);
+  return parsedSeasons.success ? parsedSeasons.data : undefined;
+}
+
+function getSeasonLabel(season: NonNullable<RootStackParamList["EpisodeList"]["seasons"]>[number]): string {
+  return season.title || `Season ${season.seasonNumber}`;
+}
+
+export function EpisodeListContainer({ params }: EpisodeListContainerProps): ReactElement {
+  const { movieRepository, watchedProgressRepository } = useRepositories();
+  const queryClient = useQueryClient();
+  const needsDetailsFallback = !params.title || !params.seasons || params.seasons.length === 0;
+  const { data: details } = useQuery({
+    queryKey: ["movies", "details", params.id],
+    queryFn: () => movieRepository.getById(params.id),
+    enabled: Boolean(params.id) && needsDetailsFallback,
+  });
+  const seasonsSource = params.seasons && params.seasons.length > 0 ? params.seasons : details?.seasons;
+  const seasons = useMemo(() => normalizeSeasons(seasonsSource) ?? [], [seasonsSource]);
+  const title = details?.primaryTitle || params.title || "Episodes";
+
+  const { data: watchedEpisodeStatuses = [] } = useQuery({
+    ...queryOptions.watchedProgress.episodes(params.id),
+    queryFn: () => watchedProgressRepository.getEpisodeStatuses(params.id),
+    enabled: Boolean(params.id),
+  });
+
+  const toggleEpisodeWatchedMutation = useMutation({
+    mutationFn: (input: EpisodeToggleInput) => {
+      const watchedInput: WatchedEpisodeInput = {
+        mediaId: params.id,
+        ...input,
+      };
+
+      return watchedProgressRepository.setEpisodeWatched(watchedInput);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries(queryOptions.watchedProgress.episodes(params.id));
+      void queryClient.invalidateQueries({ queryKey: ["watched-progress", "summary"] });
+    },
+  });
+
+  const watchedEpisodeKeys = useMemo(
+    () =>
+      new Set(
+        watchedEpisodeStatuses
+          .filter((episode) => episode.watched)
+          .map((episode) => createEpisodeWatchedKey(episode.seasonNumber, episode.episodeNumber))
+      ),
+    [watchedEpisodeStatuses]
+  );
+
+  const seasonViewModels = useMemo<EpisodeListSeasonViewModel[]>(
+    () =>
+      seasons.map((season) => {
+        const firstUnwatchedEpisode = season.episodes.find(
+          (episode) => !watchedEpisodeKeys.has(createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber))
+        );
+        const firstUnwatchedKey = firstUnwatchedEpisode
+          ? createEpisodeWatchedKey(season.seasonNumber, firstUnwatchedEpisode.episodeNumber)
+          : null;
+        const watchedCount = season.episodes.filter((episode) =>
+          watchedEpisodeKeys.has(createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber))
+        ).length;
+
+        return {
+          seasonNumber: season.seasonNumber,
+          label: getSeasonLabel(season),
+          watchedCount,
+          progressPercent: season.episodes.length > 0 ? Math.round((watchedCount / season.episodes.length) * 100) : 0,
+          episodes: season.episodes.map((episode) => {
+            const episodeKey = createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber);
+            const isWatched = watchedEpisodeKeys.has(episodeKey);
+
+            return {
+              key: episodeKey,
+              episodeNumber: episode.episodeNumber,
+              title: episode.title,
+              releaseDate: episode.releaseDate,
+              isWatched,
+              isCurrent: !isWatched && episodeKey === firstUnwatchedKey,
+            };
+          }),
+        };
+      }),
+    [seasons, watchedEpisodeKeys]
+  );
+
+  return (
+    <EpisodeListView
+      title={title}
+      seasons={seasonViewModels}
+      isUpdatingEpisodeWatched={toggleEpisodeWatchedMutation.isPending}
+      onToggleEpisodeWatched={(seasonNumber, episodeNumber, watched) =>
+        toggleEpisodeWatchedMutation.mutate({ seasonNumber, episodeNumber, watched })
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Add an EpisodeList route and screen for per-episode progress
- Make the Details episode summary open the dedicated episode list instead of rendering inline toggles
- Wire deep linking for details/:id/episodes, including the production prefix
- Fetch details by id when EpisodeList receives missing or empty season params

## Verification
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint app/_layout.tsx app/navigation/types.ts app/home/details/episodes.tsx components/views/DetailsView.tsx containers/DetailsContainer.tsx components/views/EpisodeListView.tsx containers/EpisodeListContainer.tsx
- React Doctor staged review: STATUS: PASSED
- Fresh static review: STATUS: PASSED

Closes #64