### PR TITLE
feat(home): add favorite poster queue

### DIFF
--- a/app/home/search/query.tsx
+++ b/app/home/search/query.tsx
@@ -1,12 +1,17 @@
-import { useRoute, type RouteProp } from "@react-navigation/native";
-import { type ReactElement } from "react";
+import { useNavigation, useRoute, type NavigationProp, type RouteProp } from "@react-navigation/native";
+import { useLayoutEffect, type ReactElement } from "react";
 
 import type { RootStackParamList } from "@/app/navigation/types";
 import { SearchContainer } from "@/containers/SearchContainer";
 
 export default function SearchScreen(): ReactElement {
   const route = useRoute<RouteProp<RootStackParamList, "Search">>();
+  const navigation = useNavigation<NavigationProp<RootStackParamList, "Search">>();
   const query = route.params?.query ?? "";
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerMode: "float" });
+  }, [navigation]);
 
   return <SearchContainer query={query} />;
 }

--- a/app/tabs/_layout.tsx
+++ b/app/tabs/_layout.tsx
@@ -1,12 +1,8 @@
 import { createStackNavigator } from "@react-navigation/stack";
-import * as React from "react";
 import type { ReactElement } from "react";
-import { Modal, Text, TouchableOpacity, View, useWindowDimensions } from "react-native";
+import { View } from "react-native";
 
 import type { TabParamList } from "@/app/navigation/types";
-import { AddFavoriteForm } from "@/components/forms/AddFavoriteForm";
-import { useManualFavoriteSubmission } from "@/hooks/useManualFavoriteSubmission";
-import { useThemePreference } from "@/providers/ThemePreferenceProvider";
 
 import HomeScreen from "./home";
 import FavoritesScreen from "./favorites";
@@ -14,13 +10,6 @@ import FavoritesScreen from "./favorites";
 const Stack = createStackNavigator<TabParamList>();
 
 export default function TabNavigator(): ReactElement {
-  const { palette } = useThemePreference();
-  const [showFormModal, setShowFormModal] = React.useState(false);
-  const { width } = useWindowDimensions();
-  const isDesktop = width >= 720;
-
-  const handleAddFavorite = useManualFavoriteSubmission(() => setShowFormModal(false));
-
   return (
     <View style={{ flex: 1 }}>
       <Stack.Navigator
@@ -39,79 +28,6 @@ export default function TabNavigator(): ReactElement {
           options={{ title: "Favorites" }}
         />
       </Stack.Navigator>
-
-      <TouchableOpacity
-        onPress={() => setShowFormModal(true)}
-        style={{
-          position: "absolute",
-          bottom: 88,
-          right: 20,
-          backgroundColor: palette.shellFabBackground,
-          width: 60,
-          height: 60,
-          borderRadius: 30,
-          justifyContent: "center",
-          alignItems: "center",
-          elevation: 5,
-        }}
-        accessibilityRole="button"
-        accessibilityLabel="Add favorite"
-      >
-        <Text style={{ color: palette.shellFabForeground, fontSize: 24 }}>+</Text>
-      </TouchableOpacity>
-
-      <Modal visible={showFormModal} transparent animationType="fade" onRequestClose={() => setShowFormModal(false)}>
-        <View
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: palette.shellOverlay,
-            justifyContent: "center",
-            alignItems: "center",
-            padding: 20,
-          }}
-        >
-          <View
-            style={{
-              width: isDesktop ? 560 : "100%",
-              maxWidth: 560,
-              backgroundColor: palette.shellSurface,
-              padding: 20,
-              borderRadius: 24,
-              borderColor: palette.shellBorder,
-              borderWidth: 1,
-              shadowColor: "#000000",
-              shadowOpacity: 0.1,
-              shadowRadius: 24,
-              shadowOffset: { width: 0, height: 12 },
-              elevation: 16,
-            }}
-          >
-            <TouchableOpacity
-              onPress={() => setShowFormModal(false)}
-              style={{
-                position: "absolute",
-                top: 10,
-                right: 10,
-                backgroundColor: palette.shellSurfaceAlt,
-                padding: 5,
-                borderRadius: 5,
-                zIndex: 1,
-              }}
-              accessibilityRole="button"
-              accessibilityLabel="Close add favorite modal"
-            >
-              <Text style={{ color: palette.text, fontSize: 16 }}>×</Text>
-            </TouchableOpacity>
-
-            <Text style={{ color: palette.text, fontSize: 18, marginBottom: 10 }}>Add Custom Movie</Text>
-            <AddFavoriteForm onSubmit={handleAddFavorite} />
-          </View>
-        </View>
-      </Modal>
     </View>
   );
 }

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -40,6 +40,8 @@ const MAPPING = {
   'checkmark': 'check',
   'circle': 'radio-button-unchecked',
   'tv': 'live-tv',
+  'eye.fill': 'visibility',
+  'eye': 'visibility-off',
 } as const satisfies Record<string, MaterialIconName>;
 
 type IconSymbolName = keyof typeof MAPPING;

--- a/components/views/DetailsView.tsx
+++ b/components/views/DetailsView.tsx
@@ -21,6 +21,9 @@ interface DetailsViewProps {
   isFavorite: boolean;
   isUpdatingFavorite: boolean;
   onToggleFavorite: () => void;
+  isWatched?: boolean;
+  isUpdatingWatched?: boolean;
+  onToggleWatched?: () => void;
   lastWatchedEpisodeLabel?: string;
   seriesProgress: { watched: number; total: number };
   onOpenEpisodeList: () => void;
@@ -75,6 +78,9 @@ export function DetailsView({
   isFavorite,
   isUpdatingFavorite,
   onToggleFavorite,
+  isWatched,
+  isUpdatingWatched,
+  onToggleWatched,
   lastWatchedEpisodeLabel,
   seriesProgress,
   onOpenEpisodeList,
@@ -127,6 +133,7 @@ export function DetailsView({
           borderColor: palette.shellBorder,
           borderRadius: 24,
           borderWidth: 1,
+          borderTopWidth: 0,
           backgroundColor: palette.shellSurface,
           overflow: "hidden",
         }}
@@ -179,7 +186,32 @@ export function DetailsView({
                 {isFavorite ? "Favorited" : "Favorite"}
               </Text>
             </Pressable>
-            {mediaType === "series" ? (
+            {mediaType === "movie" && onToggleWatched ? (
+              <Pressable
+                onPress={onToggleWatched}
+                disabled={isUpdatingWatched}
+                accessibilityRole="button"
+                accessibilityState={{ selected: isWatched, disabled: isUpdatingWatched }}
+                accessibilityLabel={isWatched ? `Mark ${title} as not watched` : `Mark ${title} as watched`}
+                style={{
+                  flex: 1,
+                  minHeight: 42,
+                  borderRadius: 8,
+                  borderWidth: 1,
+                  borderColor: palette.shellBorder,
+                  flexDirection: "row",
+                  gap: 8,
+                  alignItems: "center",
+                  justifyContent: "center",
+                  opacity: isUpdatingWatched ? 0.6 : 1,
+                }}
+              >
+                <IconSymbol name={isWatched ? "eye.fill" : "eye"} color="#34C759" size={18} />
+                <Text style={{ color: palette.text, fontSize: 15, fontWeight: "700" }}>
+                  {isWatched ? "Watched" : "Watch"}
+                </Text>
+              </Pressable>
+            ) : mediaType === "series" ? (
               <Pressable
                 onPress={onOpenEpisodeList}
                 accessibilityRole="button"
@@ -199,26 +231,27 @@ export function DetailsView({
                 <Text style={{ color: "#3B82F6", fontSize: 16, fontWeight: "900" }}>▶</Text>
                 <Text style={{ color: palette.text, fontSize: 15, fontWeight: "700" }}>Episodes</Text>
               </Pressable>
-            ) : null}
-            <Pressable
-              onPress={handleShare}
-              accessibilityRole="button"
-              accessibilityLabel={`Share ${title}`}
-              style={{
-                flex: 1,
-                minHeight: 42,
-                borderRadius: 8,
-                borderWidth: 1,
-                borderColor: palette.shellBorder,
-                flexDirection: "row",
-                gap: 8,
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <IconSymbol name="square.and.arrow.up" color={palette.text} size={18} />
-              <Text style={{ color: palette.text, fontSize: 15, fontWeight: "700" }}>Share</Text>
-            </Pressable>
+            ) : (
+              <Pressable
+                onPress={handleShare}
+                accessibilityRole="button"
+                accessibilityLabel={`Share ${title}`}
+                style={{
+                  flex: 1,
+                  minHeight: 42,
+                  borderRadius: 8,
+                  borderWidth: 1,
+                  borderColor: palette.shellBorder,
+                  flexDirection: "row",
+                  gap: 8,
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <IconSymbol name="square.and.arrow.up" color={palette.text} size={18} />
+                <Text style={{ color: palette.text, fontSize: 15, fontWeight: "700" }}>Share</Text>
+              </Pressable>
+            )}
           </View>
 
           {mediaType === "series" ? (
@@ -248,7 +281,15 @@ export function DetailsView({
                 <Text style={{ color: palette.text, fontSize: 13, fontWeight: "700" }}>{episodeProgressPercent}%</Text>
               </View>
               <Text style={{ color: palette.shellMutedText, fontSize: 13, lineHeight: 18 }}>
-                {lastWatchedEpisodeLabel ? `Last watched:\n${lastWatchedEpisodeLabel}` : "No watched episodes yet"}
+                {lastWatchedEpisodeLabel ? (
+                  <>
+                    <Text>Last watched:</Text>
+                    {"\n"}
+                    <Text>{lastWatchedEpisodeLabel}</Text>
+                  </>
+                ) : (
+                  <Text>No watched episodes yet</Text>
+                )}
               </Text>
             </Pressable>
           ) : null}

--- a/components/views/EpisodeListView.tsx
+++ b/components/views/EpisodeListView.tsx
@@ -24,6 +24,7 @@ export interface EpisodeListSeasonViewModel {
 interface EpisodeListViewProps {
   title: string;
   seasons: EpisodeListSeasonViewModel[];
+  initialSeasonNumber: number;
   isUpdatingEpisodeWatched: boolean;
   onToggleEpisodeWatched: (seasonNumber: number, episodeNumber: number, watched: boolean) => void;
 }
@@ -31,11 +32,12 @@ interface EpisodeListViewProps {
 export function EpisodeListView({
   title,
   seasons,
+  initialSeasonNumber,
   isUpdatingEpisodeWatched,
   onToggleEpisodeWatched,
 }: EpisodeListViewProps): ReactElement {
   const { palette } = useThemePreference();
-  const [selectedSeasonNumber, setSelectedSeasonNumber] = useState(seasons[0]?.seasonNumber ?? 0);
+  const [selectedSeasonNumber, setSelectedSeasonNumber] = useState(initialSeasonNumber);
   const [isSeasonSelectorOpen, setIsSeasonSelectorOpen] = useState(false);
   const selectedSeason = seasons.find((season) => season.seasonNumber === selectedSeasonNumber) ?? seasons[0];
   const seasonEpisodes = useMemo(() => selectedSeason?.episodes ?? [], [selectedSeason]);
@@ -58,9 +60,9 @@ export function EpisodeListView({
         contentContainerStyle={{ flexGrow: 1, padding: 16, paddingBottom: 96, gap: 14 }}
         contentInsetAdjustmentBehavior="automatic"
       >
-        <View style={{ gap: 10 }}>
+        <View style={{ gap: 10, zIndex: 2, elevation: 2 }}>
           <Text style={{ color: palette.text, fontSize: 22, lineHeight: 26, fontWeight: "800" }}>{title}</Text>
-          <View style={{ alignSelf: "flex-start", minWidth: 184 }}>
+          <View style={{ alignSelf: "flex-start", minWidth: 184, zIndex: 1000, elevation: 1000 }}>
             <TouchableOpacity
               onPress={() => setIsSeasonSelectorOpen((isOpen) => !isOpen)}
               accessibilityRole="button"
@@ -87,12 +89,22 @@ export function EpisodeListView({
             {isSeasonSelectorOpen ? (
               <View
                 style={{
+                  position: "absolute",
+                  top: "100%",
+                  left: 0,
+                  right: 0,
                   marginTop: 8,
                   borderRadius: 18,
                   borderWidth: 1,
                   borderColor: palette.shellBorder,
                   backgroundColor: palette.shellSurface,
                   overflow: "hidden",
+                  zIndex: 999,
+                  elevation: 8,
+                  shadowColor: "#000",
+                  shadowOffset: { width: 0, height: 4 },
+                  shadowOpacity: 0.15,
+                  shadowRadius: 12,
                 }}
               >
                 {seasons.map((season) => {
@@ -136,7 +148,7 @@ export function EpisodeListView({
           </View>
         </View>
 
-        <View style={{ gap: 10 }}>
+        <View style={{ gap: 10, zIndex: 1 }}>
           {seasonEpisodes.map((episode) => {
             return (
               <TouchableOpacity
@@ -166,7 +178,7 @@ export function EpisodeListView({
                 />
                 <View style={{ flex: 1, minWidth: 0, gap: 3 }}>
                   <Text style={{ color: palette.text, fontSize: 15, fontWeight: "700" }} numberOfLines={1}>
-                    {episode.episodeNumber}. {episode.title}
+                    {`Episode ${episode.episodeNumber}: ${episode.title}`}
                   </Text>
                   <Text style={{ color: palette.shellMutedText, fontSize: 13 }} numberOfLines={1}>
                     {episode.releaseDate || "Release date unavailable"}

--- a/components/views/PosterQueue.gesture.ts
+++ b/components/views/PosterQueue.gesture.ts
@@ -1,0 +1,61 @@
+import type { PosterQueueItem } from "./PosterQueue";
+
+export type SwipeDirection = "left" | "right" | "up" | "down" | "none";
+
+export const SWIPE_THRESHOLD_PX = 80;
+export const VERTICAL_THRESHOLD_PX = 60;
+
+export function classifySwipeGesture(
+  dx: number,
+  dy: number,
+  absDx: number,
+  absDy: number
+): SwipeDirection {
+  "worklet";
+  if (absDx < 10 && absDy < 10) {
+    return "none";
+  }
+  if (absDx > absDy) {
+    return dx > 0 ? "right" : "left";
+  }
+  return dy > 0 ? "down" : "up";
+}
+
+export function shouldRespondToPanGesture(
+  dx: number,
+  dy: number,
+  absDx: number,
+  absDy: number
+): boolean {
+  "worklet";
+  return absDx > 10 || absDy > 10;
+}
+
+export function createGestureState(
+  dx: number,
+  dy: number,
+  numberActiveTouches: number
+): { dx: number; dy: number; moveX: number; moveY: number; numberActiveTouches: number } {
+  return { dx, dy, moveX: 0, moveY: 0, numberActiveTouches };
+}
+
+export type GestureIntent =
+  | { type: "mark_watched" }
+  | { type: "navigate_item"; direction: "next" | "prev" }
+  | { type: "none" };
+
+export function resolveGestureIntent(
+  direction: SwipeDirection,
+  _item: PosterQueueItem
+): GestureIntent {
+  if (direction === "right") {
+    return { type: "mark_watched" };
+  }
+  if (direction === "up") {
+    return { type: "navigate_item", direction: "next" };
+  }
+  if (direction === "down") {
+    return { type: "navigate_item", direction: "prev" };
+  }
+  return { type: "none" };
+}

--- a/components/views/PosterQueue.tsx
+++ b/components/views/PosterQueue.tsx
@@ -1,0 +1,32 @@
+import type { Season } from "@/domain/entities/Movie";
+import type { FavoriteSource } from "@/domain/entities/Favorite";
+
+export interface CurrentEpisodeInfo {
+  seasonNumber: number;
+  episodeNumber: number;
+  title?: string;
+  label: string;
+}
+
+export interface PosterQueueItem {
+  key: string;
+  title: string;
+  imageSrc?: string;
+  mediaType?: "movie" | "series";
+  description?: string;
+  cast?: string[];
+  releaseDate?: string;
+  whereToWatch?: string[];
+  seasons?: Season[];
+  source?: FavoriteSource;
+  watchStatus?: "favorite" | "watched" | "watching" | "not-started";
+  progressLabel?: string;
+  progressPercent?: number;
+  currentEpisode?: CurrentEpisodeInfo;
+  nextEpisodeLabel?: string;
+}
+
+export interface PosterQueueViewModel {
+  items: PosterQueueItem[];
+  currentIndex: number;
+}

--- a/components/views/PosterQueueView.tsx
+++ b/components/views/PosterQueueView.tsx
@@ -1,0 +1,426 @@
+import { useRef, type ReactElement } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  PanResponder,
+} from "react-native";
+import type { GestureResponderEvent } from "react-native";
+import { Image } from "expo-image";
+
+import type { PosterQueueItem } from "./PosterQueue";
+import { useThemePreference } from "@/providers/ThemePreferenceProvider";
+import { IconSymbol } from "@/components/ui/IconSymbol";
+import { classifySwipeGesture, type SwipeDirection } from "./PosterQueue.gesture";
+
+interface PosterQueueViewProps {
+  items: PosterQueueItem[];
+  currentIndex: number;
+  isLoading?: boolean;
+  errorMessage?: string;
+  onOpenDetails: (item: PosterQueueItem) => void;
+  onMarkWatched: (item: PosterQueueItem) => void;
+  onNavigateNext?: () => void;
+  onNavigatePrev?: () => void;
+  activeSectionLabel?: string;
+}
+
+interface GesturePoint {
+  x: number;
+  y: number;
+}
+
+function getGesturePoint(event: GestureResponderEvent): GesturePoint {
+  return {
+    x: event.nativeEvent.pageX,
+    y: event.nativeEvent.pageY,
+  };
+}
+
+export function PosterQueueView({
+  items,
+  currentIndex,
+  isLoading,
+  errorMessage,
+  onOpenDetails,
+  onMarkWatched,
+  onNavigateNext,
+  onNavigatePrev,
+}: PosterQueueViewProps): ReactElement | null {
+  const { palette } = useThemePreference();
+  const gestureStartRef = useRef<GesturePoint | null>(null);
+  const gestureLastRef = useRef<GesturePoint | null>(null);
+
+  if (isLoading) {
+    return (
+      <View style={[styles.messageContainer, { backgroundColor: palette.shellBackground }]}>
+        <Text style={{ color: palette.text, fontSize: 18 }}>Loading movies...</Text>
+      </View>
+    );
+  }
+
+  if (errorMessage) {
+    return (
+      <View style={[styles.messageContainer, { backgroundColor: palette.shellBackground }]}>
+        <Text style={{ color: palette.text, fontSize: 18 }}>Error loading movies</Text>
+        <Text style={{ color: palette.shellMutedText, fontSize: 14, marginTop: 10 }}>{errorMessage}</Text>
+      </View>
+    );
+  }
+
+  if (items.length === 0 || currentIndex < 0 || currentIndex >= items.length) {
+    return null;
+  }
+
+  const item = items[currentIndex] as typeof items[number] & {
+    currentEpisode?: { label: string };
+    watchedCount?: number;
+    totalCount?: number;
+    progressLabel?: string;
+    progressPercent?: number;
+    nextEpisodeLabel?: string;
+  };
+  const fallbackImage = require("../../assets/images/logo.png");
+
+  function getStatusColor(status: NonNullable<PosterQueueItem["watchStatus"]>, tint: string, success: string, watching: string, muted: string): string {
+    switch (status) {
+      case "favorite": return tint;
+      case "watched": return success;
+      case "watching": return watching;
+      case "not-started": return muted;
+    }
+  }
+
+  function getStatusIconName(status: NonNullable<PosterQueueItem["watchStatus"]>): "heart.fill" | "checkmark" | "arrow.up.right" | "circle" {
+    switch (status) {
+      case "favorite": return "heart.fill";
+      case "watched": return "checkmark";
+      case "watching": return "arrow.up.right";
+      case "not-started": return "circle";
+    }
+  }
+
+  function getStatusLabel(status: NonNullable<PosterQueueItem["watchStatus"]>): string {
+    switch (status) {
+      case "favorite": return "Favorite";
+      case "watched": return "Watched";
+      case "watching": return "Watching";
+      case "not-started": return "Not Started";
+    }
+  }
+
+  function renderStatusPill(status: NonNullable<PosterQueueItem["watchStatus"]>, pal: typeof palette): ReactElement {
+    const color = getStatusColor(status, pal.tint, "#7CFF4E", "#3B82F6", pal.shellMutedText);
+    return (
+      <View
+        style={[
+          styles.statusPill,
+          {
+            backgroundColor: status === "not-started" ? pal.shellBackground : `${color}22`,
+            borderColor: status === "not-started" ? pal.shellBorder : `${color}55`,
+          },
+        ]}
+      >
+        <IconSymbol name={getStatusIconName(status)} color={color} size={14} />
+        <Text style={[styles.statusPillText, { color }]}>{getStatusLabel(status)}</Text>
+      </View>
+    );
+  }
+
+  function handleGestureRelease(direction: SwipeDirection): void {
+    if (direction === "none") {
+      onOpenDetails(item);
+    } else if (direction === "right") {
+      onMarkWatched(item);
+    } else if (direction === "up" && onNavigateNext) {
+      onNavigateNext();
+    } else if (direction === "down" && onNavigatePrev) {
+      onNavigatePrev();
+    }
+  }
+
+  const swipePanResponder = PanResponder.create({
+    onStartShouldSetPanResponder: () => true,
+    onMoveShouldSetPanResponder: (_, { dx, dy }) => Math.abs(dx) > 10 || Math.abs(dy) > 10,
+    onPanResponderGrant: (event) => {
+      const point = getGesturePoint(event);
+      gestureStartRef.current = point;
+      gestureLastRef.current = point;
+    },
+    onPanResponderMove: (event) => {
+      gestureLastRef.current = getGesturePoint(event);
+    },
+    onPanResponderRelease: (event, gestureState) => {
+      const startPoint = gestureStartRef.current;
+      const releasePoint = getGesturePoint(event);
+      const fallbackEndPoint = gestureLastRef.current ?? releasePoint;
+      const manualDx = startPoint ? fallbackEndPoint.x - startPoint.x : 0;
+      const manualDy = startPoint ? fallbackEndPoint.y - startPoint.y : 0;
+      const dx = Math.abs(manualDx) > Math.abs(gestureState.dx) ? manualDx : gestureState.dx;
+      const dy = Math.abs(manualDy) > Math.abs(gestureState.dy) ? manualDy : gestureState.dy;
+
+      gestureStartRef.current = null;
+      gestureLastRef.current = null;
+
+      const direction = classifySwipeGesture(
+        dx,
+        dy,
+        Math.abs(dx),
+        Math.abs(dy)
+      );
+      handleGestureRelease(direction);
+    },
+    onPanResponderTerminate: () => {
+      gestureStartRef.current = null;
+      gestureLastRef.current = null;
+    },
+  });
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: palette.shellBackground }]}
+      {...swipePanResponder.panHandlers}
+    >
+      <View
+        style={styles.touchable}
+        accessibilityRole="button"
+        accessibilityLabel={`${item.title} ${item.mediaType === "series" ? "Series" : "Movie"} Tap to view details Swipe right to mark as watched`}
+      >
+        <View style={styles.cardWrapper}>
+          <View
+            style={[styles.card, { backgroundColor: palette.shellSurface, borderRadius: 24 }]}
+          >
+            <Image
+              placeholder={fallbackImage}
+              source={{ uri: item.imageSrc }}
+              style={[styles.posterImage, { borderRadius: 20 }]}
+              resizeMode="cover"
+            />
+            <View style={[styles.overlayGradient, { borderRadius: 20 }]} />
+            <View style={styles.mediaBadge}>
+              <Text style={[styles.mediaBadgeText, { color: palette.text }]}>
+                {item.mediaType === "series" ? "SERIES" : "MOVIE"}
+              </Text>
+            </View>
+            {item.watchStatus && (
+              <View style={styles.statusPillWrapper}>
+                {renderStatusPill(item.watchStatus, palette)}
+              </View>
+            )}
+            {item.currentEpisode ? (
+              <View style={styles.seriesOverlay}>
+                <View style={styles.seriesOverlayTopRow}>
+                  <Text
+                    style={[styles.seriesOverlayTitle, { color: "#fff" }]}
+                    numberOfLines={1}
+                  >
+                    {item.title}
+                  </Text>
+                  <Text style={[styles.seriesOverlayPercent, { color: palette.tint }]}>
+                    {item.progressPercent ?? 0}%
+                  </Text>
+                </View>
+                <Text style={[styles.seriesOverlayEpisode, { color: "rgba(255,255,255,0.9)" }]}>
+                  {item.currentEpisode.label}
+                </Text>
+                <View style={styles.seriesOverlayProgressRow}>
+                  <Text style={[styles.seriesOverlayProgressLabel, { color: "rgba(255,255,255,0.7)" }]}>
+                    {item.progressLabel}
+                  </Text>
+                </View>
+                <View style={styles.seriesOverlayTrack}>
+                  <View
+                    style={[
+                      styles.seriesOverlayFill,
+                      { width: `${item.progressPercent ?? 0}%`, backgroundColor: "#3B82F6" },
+                    ]}
+                  />
+                </View>
+                <View style={styles.seriesOverlayHintRow}>
+                  <Text style={[styles.seriesOverlayHint, { color: "rgba(255,255,255,0.6)" }]}>
+                    Swipe Right to Mark as Watched
+                  </Text>
+                  <Text style={[styles.seriesOverlayHintArrow, { color: palette.tint }]}>→</Text>
+                </View>
+              </View>
+            ) : (
+              <View style={styles.basicOverlay}>
+                <Text style={[styles.basicOverlayTitle, { color: "#fff" }]} numberOfLines={2}>
+                  {item.title}
+                </Text>
+                <View style={styles.seriesOverlayHintRow}>
+                  <Text style={[styles.seriesOverlayHint, { color: "rgba(255,255,255,0.6)" }]}>Swipe Right to Mark as Watched</Text>
+                  <Text style={[styles.seriesOverlayHintArrow, { color: palette.tint }]}>→</Text>
+                </View>
+              </View>
+            )}
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    paddingTop: 16,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+  messageContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 20,
+  },
+  touchable: {
+    flex: 1,
+    alignItems: "center",
+    width: "100%",
+  },
+  cardWrapper: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+  },
+  card: {
+    flex: 1,
+    width: "100%",
+    overflow: "hidden",
+    elevation: 4,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+  },
+  posterImage: {
+    ...StyleSheet.absoluteFillObject,
+    width: "100%",
+  },
+  overlayGradient: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: 80,
+    backgroundColor: "transparent",
+  },
+  mediaBadge: {
+    position: "absolute",
+    top: 12,
+    left: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    backgroundColor: "rgba(0,0,0,0.6)",
+  },
+  mediaBadgeText: {
+    fontSize: 11,
+    fontWeight: "700",
+  },
+  statusPillWrapper: {
+    position: "absolute",
+    top: 12,
+    right: 12,
+  },
+  statusPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    gap: 3,
+  },
+  statusPillText: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  seriesOverlay: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    paddingHorizontal: 14,
+    paddingBottom: 14,
+    paddingTop: 48,
+    backgroundColor: "rgba(0,0,0,0.72)",
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+  },
+  basicOverlay: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    paddingHorizontal: 14,
+    paddingBottom: 14,
+    paddingTop: 64,
+    backgroundColor: "rgba(0,0,0,0.64)",
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+  },
+  basicOverlayTitle: {
+    fontSize: 20,
+    fontWeight: "700",
+    marginBottom: 10,
+  },
+  seriesOverlayTopRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 2,
+  },
+  seriesOverlayTitle: {
+    fontSize: 15,
+    fontWeight: "700",
+    flex: 1,
+    marginRight: 8,
+  },
+  seriesOverlayPercent: {
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  seriesOverlayEpisode: {
+    fontSize: 12,
+    fontWeight: "600",
+    marginBottom: 6,
+  },
+  seriesOverlayProgressRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 5,
+  },
+  seriesOverlayProgressLabel: {
+    fontSize: 11,
+    fontWeight: "500",
+  },
+  seriesOverlayTrack: {
+    height: 4,
+    borderRadius: 999,
+    overflow: "hidden",
+    backgroundColor: "rgba(255,255,255,0.2)",
+    marginBottom: 8,
+  },
+  seriesOverlayFill: {
+    height: "100%",
+    borderRadius: 999,
+  },
+  seriesOverlayHintRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 5,
+  },
+  seriesOverlayHint: {
+    fontSize: 11,
+    fontWeight: "500",
+  },
+  seriesOverlayHintArrow: {
+    fontSize: 13,
+    fontWeight: "700",
+  },
+});

--- a/containers/DetailsContainer.tsx
+++ b/containers/DetailsContainer.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigation, type NavigationProp } from "@react-navigation/native";
 import { useMemo, type ReactElement } from "react";
 import { z } from "zod";
@@ -109,6 +109,22 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
   );
   const seasons = normalizeSeasons(data?.seasons ?? manualDetails?.seasons ?? params.seasons);
   const imageSrc = data?.primaryImage?.url || manualDetails?.url || params.imageSrc;
+
+  const { data: watchedMovieStatus } = useQuery({
+    ...queryOptions.watchedProgress.movie(params.id),
+    queryFn: () => watchedProgressRepository.getMovieStatus(params.id),
+    enabled: Boolean(params.id) && mediaType === "movie",
+  });
+
+  const queryClient = useQueryClient();
+
+  const toggleWatchedMutation = useMutation({
+    mutationFn: (watched: boolean) => watchedProgressRepository.setMovieWatched(params.id, watched),
+    onSuccess: () => {
+      void queryClient.invalidateQueries(queryOptions.watchedProgress.movie(params.id));
+      void queryClient.invalidateQueries({ queryKey: ["watched-progress", "summary"] });
+    },
+  });
 
   const watchedEpisodeKeys = useMemo(() => {
     return new Set(
@@ -221,6 +237,14 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
     }
   };
 
+  const handleToggleWatched = (): void => {
+    if (watchedMovieStatus?.watched) {
+      void toggleWatchedMutation.mutateAsync(false);
+    } else {
+      void toggleWatchedMutation.mutateAsync(true);
+    }
+  };
+
   return (
     <DetailsView
       isLoading={showBlockingLoading}
@@ -236,6 +260,9 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
       isFavorite={isFavorite}
       isUpdatingFavorite={isAdding || isRemoving}
       onToggleFavorite={handleToggleFavorite}
+      isWatched={watchedMovieStatus?.watched}
+      isUpdatingWatched={toggleWatchedMutation.isPending}
+      onToggleWatched={handleToggleWatched}
       lastWatchedEpisodeLabel={lastWatchedEpisodeLabel}
       seriesProgress={seriesProgress}
       onOpenEpisodeList={() =>

--- a/containers/EpisodeListContainer.tsx
+++ b/containers/EpisodeListContainer.tsx
@@ -119,10 +119,24 @@ export function EpisodeListContainer({ params }: EpisodeListContainerProps): Rea
     [seasons, watchedEpisodeKeys]
   );
 
+  const initialSeasonNumber = useMemo<number>(() => {
+    if (seasons.length === 0) {
+      return 0;
+    }
+    const currentOrNextSeason = seasons.find((season) => {
+      const firstUnwatchedEpisode = season.episodes.find(
+        (episode) => !watchedEpisodeKeys.has(createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber))
+      );
+      return firstUnwatchedEpisode !== undefined;
+    });
+    return currentOrNextSeason?.seasonNumber ?? seasons[seasons.length - 1].seasonNumber;
+  }, [seasons, watchedEpisodeKeys]);
+
   return (
     <EpisodeListView
       title={title}
       seasons={seasonViewModels}
+      initialSeasonNumber={initialSeasonNumber}
       isUpdatingEpisodeWatched={toggleEpisodeWatchedMutation.isPending}
       onToggleEpisodeWatched={(seasonNumber, episodeNumber, watched) =>
         toggleEpisodeWatchedMutation.mutate({ seasonNumber, episodeNumber, watched })

--- a/containers/FavoritesContainer.tsx
+++ b/containers/FavoritesContainer.tsx
@@ -1,13 +1,17 @@
 import { useState, type ReactElement } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigation, type NavigationProp } from "@react-navigation/native";
+import { Modal, Text, TouchableOpacity, View, useWindowDimensions } from "react-native";
 
 import type { RootStackParamList } from "@/app/navigation/types";
+import { AddFavoriteForm } from "@/components/forms/AddFavoriteForm";
 import { FavoritesView, type FavoriteSortDirection } from "@/components/views/FavoritesView";
 import { queryOptions } from "@/constants/query";
 import type { Favorite } from "@/domain/entities/Favorite";
 import { useFavoriteMutations } from "@/hooks/useFavoriteMutations";
 import { useRepositories } from "@/providers/RepositoryProvider";
+import { useManualFavoriteSubmission } from "@/hooks/useManualFavoriteSubmission";
+import { useThemePreference } from "@/providers/ThemePreferenceProvider";
 
 type FilterOption = "movie" | "series" | undefined;
 
@@ -34,6 +38,10 @@ function sortFavoritesByAddedAt(favorites: Favorite[], direction: FavoriteSortDi
 
 export function FavoritesContainer(): ReactElement {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const { palette } = useThemePreference();
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 720;
+  const [showFormModal, setShowFormModal] = useState(false);
   const { favoriteRepository } = useRepositories();
   const [filter, setFilter] = useState<FilterOption>(undefined);
   const [sortDirection, setSortDirection] = useState<FavoriteSortDirection>("newest");
@@ -42,6 +50,7 @@ export function FavoritesContainer(): ReactElement {
     queryFn: () => favoriteRepository.getByMediaType(filter),
   });
   const { addFavorite, removeFavorite } = useFavoriteMutations();
+  const handleAddFavorite = useManualFavoriteSubmission(() => setShowFormModal(false));
 
   const favoriteIds = new Set(data?.map((item) => item.id) ?? []);
   const sortedFavorites = sortFavoritesByAddedAt(data ?? [], sortDirection);
@@ -60,47 +69,119 @@ export function FavoritesContainer(): ReactElement {
   }));
 
   return (
-    <FavoritesView
-      filter={filter}
-      onFilterChange={setFilter}
-      sortDirection={sortDirection}
-      onSortDirectionChange={setSortDirection}
-      isLoading={isLoading}
-      errorMessage={error?.message}
-      masonryData={masonryData}
-      favoriteIds={favoriteIds}
-      onAddFavorite={(item) =>
-        addFavorite({
-          id: item.key,
-          title: item.title,
-          mediaType: item.mediaType || "movie",
-          url: item.imageSrc,
-          description: item.description || "Not available",
-          cast: item.cast && item.cast.length > 0 ? item.cast : ["Not available"],
-          releaseDate: item.releaseDate || "Not available",
-          whereToWatch:
-            item.whereToWatch && item.whereToWatch.length > 0
-              ? item.whereToWatch
-              : ["Not available"],
-          seasons: item.seasons,
-          source: "catalog",
-        })
-      }
-      onRemoveFavorite={(item) => removeFavorite(item.key)}
-      onOpenDetails={(item) =>
-        navigation.navigate("Details", {
-          id: item.key,
-          title: item.title,
-          mediaType: item.mediaType || "movie",
-          imageSrc: item.imageSrc,
-          description: item.description,
-          cast: item.cast,
-          releaseDate: item.releaseDate,
-          whereToWatch: item.whereToWatch,
-          seasons: item.seasons,
-          source: item.source,
-        })
-      }
-    />
+    <View style={{ flex: 1 }}>
+      <FavoritesView
+        filter={filter}
+        onFilterChange={setFilter}
+        sortDirection={sortDirection}
+        onSortDirectionChange={setSortDirection}
+        isLoading={isLoading}
+        errorMessage={error?.message}
+        masonryData={masonryData}
+        favoriteIds={favoriteIds}
+        onAddFavorite={(item) =>
+          addFavorite({
+            id: item.key,
+            title: item.title,
+            mediaType: item.mediaType || "movie",
+            url: item.imageSrc,
+            description: item.description || "Not available",
+            cast: item.cast && item.cast.length > 0 ? item.cast : ["Not available"],
+            releaseDate: item.releaseDate || "Not available",
+            whereToWatch:
+              item.whereToWatch && item.whereToWatch.length > 0
+                ? item.whereToWatch
+                : ["Not available"],
+            seasons: item.seasons,
+            source: "catalog",
+          })
+        }
+        onRemoveFavorite={(item) => removeFavorite(item.key)}
+        onOpenDetails={(item) =>
+          navigation.navigate("Details", {
+            id: item.key,
+            title: item.title,
+            mediaType: item.mediaType || "movie",
+            imageSrc: item.imageSrc,
+            description: item.description,
+            cast: item.cast,
+            releaseDate: item.releaseDate,
+            whereToWatch: item.whereToWatch,
+            seasons: item.seasons,
+            source: item.source,
+          })
+        }
+      />
+      <TouchableOpacity
+        onPress={() => setShowFormModal(true)}
+        style={{
+          position: "absolute",
+          bottom: 88,
+          right: 20,
+          backgroundColor: palette.shellFabBackground,
+          width: 60,
+          height: 60,
+          borderRadius: 30,
+          justifyContent: "center",
+          alignItems: "center",
+          elevation: 5,
+        }}
+        accessibilityRole="button"
+        accessibilityLabel="Add favorite"
+      >
+        <Text style={{ color: palette.shellFabForeground, fontSize: 24 }}>+</Text>
+      </TouchableOpacity>
+      <Modal visible={showFormModal} transparent animationType="fade" onRequestClose={() => setShowFormModal(false)}>
+        <View
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: palette.shellOverlay,
+            justifyContent: "center",
+            alignItems: "center",
+            padding: 20,
+          }}
+        >
+          <View
+            style={{
+              width: isDesktop ? 560 : "100%",
+              maxWidth: 560,
+              backgroundColor: palette.shellSurface,
+              padding: 20,
+              borderRadius: 24,
+              borderColor: palette.shellBorder,
+              borderWidth: 1,
+              shadowColor: "#000000",
+              shadowOpacity: 0.1,
+              shadowRadius: 24,
+              shadowOffset: { width: 0, height: 12 },
+              elevation: 16,
+            }}
+          >
+            <TouchableOpacity
+              onPress={() => setShowFormModal(false)}
+              style={{
+                position: "absolute",
+                top: 10,
+                right: 10,
+                backgroundColor: palette.shellSurfaceAlt,
+                padding: 5,
+                borderRadius: 5,
+                zIndex: 1,
+              }}
+              accessibilityRole="button"
+              accessibilityLabel="Close add favorite modal"
+            >
+              <Text style={{ color: palette.text, fontSize: 16 }}>×</Text>
+            </TouchableOpacity>
+            <Text style={{ color: palette.text, fontSize: 18, marginBottom: 10 }}>Add Custom Movie</Text>
+            <AddFavoriteForm onSubmit={handleAddFavorite} />
+          </View>
+        </View>
+      </Modal>
+    </View>
   );
 }

--- a/containers/HomeContainer.tsx
+++ b/containers/HomeContainer.tsx
@@ -1,95 +1,329 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigation, type NavigationProp } from "@react-navigation/native";
-import { useMemo, type ReactElement } from "react";
+import { useCallback, useMemo, useState, type ReactElement } from "react";
+import Toast from "react-native-toast-message";
 
 import type { RootStackParamList } from "@/app/navigation/types";
-import { HomeView } from "@/components/views/HomeView";
+import type { PosterQueueItem } from "@/components/views/PosterQueue";
+import { PosterQueueView } from "@/components/views/PosterQueueView";
 import { queryOptions } from "@/constants/query";
-import { inferMovieMediaType } from "@/domain/entities/Movie";
-import { useFavoriteMutations } from "@/hooks/useFavoriteMutations";
+import { createEpisodeWatchedKey } from "@/domain/entities/WatchedProgress";
 import { useRepositories } from "@/providers/RepositoryProvider";
-import { getWatchStatusByMediaId } from "./watchStatusViewModel";
+import type { Season } from "@/domain/entities/Movie";
+
+interface CurrentEpisodeInfo {
+  seasonNumber: number;
+  episodeNumber: number;
+  title?: string;
+  label: string;
+}
+
+interface EnrichedFavoriteItem extends PosterQueueItem {
+  currentEpisode?: CurrentEpisodeInfo;
+  watchedCount: number;
+  totalCount: number;
+  progressLabel: string;
+  progressPercent: number;
+  nextEpisodeLabel?: string;
+}
 
 export function HomeContainer(): ReactElement {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
-  const { movieRepository, favoriteRepository, watchedProgressRepository } = useRepositories();
-  const { data, isLoading, error } = useQuery({
-    ...queryOptions.movies.random,
-    queryFn: () => movieRepository.getRandom(),
-  });
+  const queryClient = useQueryClient();
+  const { watchedProgressRepository, favoriteRepository, movieRepository } = useRepositories();
 
-  const { data: favorites } = useQuery({
+  const { data: favoritesData, isLoading: isLoadingFavorites, error: errorFavorites } = useQuery({
     ...queryOptions.movies.favorites,
     queryFn: () => favoriteRepository.getAll(),
   });
 
-  const { addFavorite, removeFavorite } = useFavoriteMutations();
-
-  const movies = useMemo(
+  const favoriteItems = useMemo(
     () =>
-      data?.titles?.map((item) => ({
-        key: item.id,
-        imageSrc: item.primaryImage?.url,
-        title: item.primaryTitle,
-        mediaType: inferMovieMediaType(item.type),
-        description: item.plot,
-        cast: item.cast,
-        releaseDate: item.releaseDate || item.startYear?.toString(),
-        whereToWatch: item.whereToWatch,
-        seasons: item.seasons,
-      })) || [],
-    [data?.titles],
+      (favoritesData ?? []).map((fav) => ({
+        key: fav.id,
+        imageSrc: fav.url,
+        title: fav.title,
+        mediaType: fav.mediaType,
+        description: fav.description,
+        cast: fav.cast,
+        releaseDate: fav.releaseDate,
+        whereToWatch: fav.whereToWatch,
+        seasons: fav.seasons,
+        source: fav.source,
+        watchStatus: "favorite" as const,
+      })),
+    [favoritesData],
   );
 
-  const favoriteIds = useMemo(() => new Set(favorites?.map((item) => item.id) ?? []), [favorites]);
-  const { data: watchStatusByMediaId = {} } = useQuery({
-    queryKey: ["watched-progress", "summary", movies.map((item) => item.key).sort()],
-    queryFn: () => getWatchStatusByMediaId(movies, watchedProgressRepository),
-    enabled: movies.length > 0,
+  const favoriteIds = useMemo(
+    () => favoriteItems.map((item) => item.key).filter(Boolean),
+    [favoriteItems],
+  );
+
+  const seriesFavoriteIdsWithoutSeasons = useMemo(
+    () =>
+      favoriteItems
+        .filter((item) => item.mediaType === "series" && (!item.seasons || item.seasons.length === 0))
+        .map((item) => item.key),
+    [favoriteItems],
+  );
+
+  const seriesDetailsHydration = useQuery({
+    queryKey: ["home-series-details", [...seriesFavoriteIdsWithoutSeasons].sort()],
+    queryFn: async (): Promise<Record<string, Season[]>> => {
+      const results: Record<string, Season[]> = {};
+      await Promise.all(
+        seriesFavoriteIdsWithoutSeasons.map(async (id) => {
+          try {
+            const details = await movieRepository.getById(id);
+            if (details?.seasons && details.seasons.length > 0) {
+              results[id] = details.seasons;
+            }
+          } catch {
+            // Non-blocking: keep favorite visible but without episode info
+          }
+        }),
+      );
+      return results;
+    },
+    enabled: seriesFavoriteIdsWithoutSeasons.length > 0,
   });
-  const moviesWithWatchStatus = movies.map((item) => ({
-    ...item,
-    ...watchStatusByMediaId[item.key],
-  }));
+
+  const movieWatchStatusQuery = useQuery({
+    queryKey: ["watched-progress", "movies", "home-queue", [...favoriteIds].sort()],
+    queryFn: async (): Promise<Record<string, boolean>> => {
+      const results: Record<string, boolean> = {};
+      await Promise.all(
+        favoriteItems
+          .filter((m) => m.mediaType === "movie")
+          .map(async (m) => {
+            const status = await watchedProgressRepository.getMovieStatus(m.key);
+            results[m.key] = status?.watched ?? false;
+          }),
+      );
+      return results;
+    },
+    enabled: favoriteIds.length > 0,
+  });
+
+  const episodeStatusQueries = useQuery({
+    queryKey: ["watched-progress", "episodes", "home-queue", [...favoriteIds].sort()],
+    queryFn: async () => {
+      const results: Record<string, { seasonNumber: number; episodeNumber: number; watched: boolean; title?: string }[]> = {};
+      await Promise.all(
+        favoriteItems
+          .filter((m) => m.mediaType === "series")
+          .map(async (m) => {
+            const episodes = await watchedProgressRepository.getEpisodeStatuses(m.key);
+            results[m.key] = episodes;
+          }),
+      );
+      return results;
+    },
+    enabled: favoriteIds.length > 0,
+  });
+
+  const enrichedFavoriteItems = useMemo((): EnrichedFavoriteItem[] => {
+    return favoriteItems
+      .filter((item): boolean => {
+        if (item.mediaType === "movie") {
+          return !(movieWatchStatusQuery.data?.[item.key] === true);
+        }
+        return true;
+      })
+      .map((item): EnrichedFavoriteItem => {
+        const base = {
+          ...item,
+          watchedCount: 0,
+          totalCount: 0,
+          progressLabel: "",
+          progressPercent: 0,
+        };
+        if (item.mediaType !== "series" || !episodeStatusQueries.data) {
+          return base;
+        }
+
+        const seasons = item.seasons ?? seriesDetailsHydration.data?.[item.key];
+        if (!seasons || seasons.length === 0) {
+          return base;
+        }
+
+        const episodes = episodeStatusQueries.data[item.key] ?? [];
+        const watchedKeys = new Set(
+          episodes.filter((e) => e.watched).map((e) => createEpisodeWatchedKey(e.seasonNumber, e.episodeNumber))
+        );
+
+        let totalEpisodes = 0;
+        let watchedEpisodes = 0;
+        let firstUnwatched: { seasonNumber: number; episodeNumber: number; title?: string } | undefined;
+        let nextUnwatched: { seasonNumber: number; episodeNumber: number; title?: string } | undefined;
+        let foundFirst = false;
+
+        for (const season of seasons) {
+          for (const episode of season.episodes) {
+            totalEpisodes++;
+            const key = createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber);
+            if (watchedKeys.has(key)) {
+              watchedEpisodes++;
+            } else {
+              if (!foundFirst) {
+                firstUnwatched = { seasonNumber: season.seasonNumber, episodeNumber: episode.episodeNumber, title: episode.title };
+                foundFirst = true;
+              } else if (!nextUnwatched) {
+                nextUnwatched = { seasonNumber: season.seasonNumber, episodeNumber: episode.episodeNumber, title: episode.title };
+              }
+            }
+          }
+        }
+
+        const currentEpisode: CurrentEpisodeInfo | undefined = firstUnwatched
+          ? {
+              seasonNumber: firstUnwatched.seasonNumber,
+              episodeNumber: firstUnwatched.episodeNumber,
+              title: firstUnwatched.title,
+              label: `S${firstUnwatched.seasonNumber}E${firstUnwatched.episodeNumber}${firstUnwatched.title ? ` \u2022 ${firstUnwatched.title}` : ""}`,
+            }
+          : undefined;
+
+        return {
+          ...base,
+          watchedCount: watchedEpisodes,
+          totalCount: totalEpisodes,
+          progressLabel: `${watchedEpisodes} / ${totalEpisodes} Episodes`,
+          progressPercent: totalEpisodes > 0 ? Math.round((watchedEpisodes / totalEpisodes) * 100) : 0,
+          currentEpisode,
+          nextEpisodeLabel: nextUnwatched
+            ? `S${nextUnwatched.seasonNumber}E${nextUnwatched.episodeNumber}${nextUnwatched.title ? ` \u2022 ${nextUnwatched.title}` : ""}`
+            : undefined,
+        };
+      })
+      .filter((item): boolean => {
+        if (item.mediaType === "series") {
+          const seasons = item.seasons ?? seriesDetailsHydration.data?.[item.key];
+          if (seasons && seasons.length > 0 && item.totalCount > 0 && item.watchedCount === item.totalCount) {
+            return false;
+          }
+        }
+        return true;
+      });
+  }, [favoriteItems, movieWatchStatusQuery.data, episodeStatusQueries.data, seriesDetailsHydration.data]);
+
+  const [activeFavoriteIndex, setActiveFavoriteIndex] = useState(0);
+
+  const clampedActiveIndex = useMemo(() => {
+    if (enrichedFavoriteItems.length === 0) return 0;
+    return Math.min(Math.max(0, activeFavoriteIndex), enrichedFavoriteItems.length - 1);
+  }, [activeFavoriteIndex, enrichedFavoriteItems.length]);
+
+  const markMovieWatchedMutation = useMutation({
+    mutationFn: (mediaId: string) => watchedProgressRepository.setMovieWatched(mediaId, true),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["watched-progress"] });
+    },
+    onError: (err) => {
+      console.error("[HomeContainer] markMovieWatched failed:", err);
+      Toast.show({ type: "error", text1: "Failed to mark as watched. Please try again." });
+    },
+  });
+
+  const markEpisodeWatchedMutation = useMutation({
+    mutationFn: (input: { mediaId: string; seasonNumber: number; episodeNumber: number }) =>
+      watchedProgressRepository.setEpisodeWatched({
+        mediaId: input.mediaId,
+        seasonNumber: input.seasonNumber,
+        episodeNumber: input.episodeNumber,
+        watched: true,
+      }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["watched-progress"] });
+    },
+    onError: (err) => {
+      console.error("[HomeContainer] markEpisodeWatched failed:", err);
+      Toast.show({ type: "error", text1: "Failed to mark episode as watched. Please try again." });
+    },
+  });
+
+  const handleOpenDetails = useCallback(
+    (item: PosterQueueItem): void => {
+      navigation.navigate("Details", {
+        id: item.key,
+        title: item.title,
+        mediaType: item.mediaType || "movie",
+        imageSrc: item.imageSrc,
+        description: item.description,
+        cast: item.cast,
+        releaseDate: item.releaseDate,
+        whereToWatch: item.whereToWatch,
+        seasons: item.seasons,
+        source: item.source || "catalog",
+      });
+    },
+    [navigation],
+  );
+
+  const handleMarkWatchedAsync = useCallback(
+    async (item: EnrichedFavoriteItem): Promise<boolean> => {
+      if (item.mediaType === "series" && item.currentEpisode) {
+        const { seasonNumber, episodeNumber } = item.currentEpisode;
+        await markEpisodeWatchedMutation.mutateAsync({
+          mediaId: item.key,
+          seasonNumber,
+          episodeNumber,
+        });
+      } else if (item.mediaType === "movie") {
+        await markMovieWatchedMutation.mutateAsync(item.key);
+      }
+      return true;
+    },
+    [markEpisodeWatchedMutation, markMovieWatchedMutation],
+  );
+
+  const handleNavigateNext = useCallback((): void => {
+    if (enrichedFavoriteItems.length === 0) return;
+    setActiveFavoriteIndex((prev) => (prev + 1) % enrichedFavoriteItems.length);
+  }, [enrichedFavoriteItems.length]);
+
+  const handleNavigatePrev = useCallback((): void => {
+    if (enrichedFavoriteItems.length === 0) return;
+    setActiveFavoriteIndex((prev) => (prev - 1 + enrichedFavoriteItems.length) % enrichedFavoriteItems.length);
+  }, [enrichedFavoriteItems.length]);
+
+  const handleMarkWatchedAndAdvance = useCallback(
+    async (item: PosterQueueItem): Promise<void> => {
+      const enriched = item as EnrichedFavoriteItem;
+      const watchedLabel = enriched.currentEpisode?.label ?? enriched.title;
+      try {
+        await handleMarkWatchedAsync(enriched);
+        if (enriched.mediaType === "series") {
+          Toast.show({
+            type: "success",
+            text1: `Marked: ${watchedLabel}`,
+            text2: enriched.nextEpisodeLabel ? `Next: ${enriched.nextEpisodeLabel}` : "All episodes watched",
+            visibilityTime: 2500,
+            position: "bottom",
+          });
+        }
+      } catch {
+        // mutation error already handled in onError — do not advance
+      }
+    },
+    [handleMarkWatchedAsync],
+  );
+
+  const isLoading = isLoadingFavorites;
+  const error = errorFavorites;
 
   return (
-    <HomeView
+    <PosterQueueView
       isLoading={isLoading}
       errorMessage={error?.message}
-      movies={moviesWithWatchStatus}
-      favoriteIds={favoriteIds}
-      onAddFavorite={(item) =>
-        addFavorite({
-          id: item.key,
-          title: item.title,
-          mediaType: item.mediaType || "movie",
-          url: item.imageSrc,
-          description: item.description || "No disponible",
-          cast: item.cast && item.cast.length > 0 ? item.cast : ["No disponible"],
-          releaseDate: item.releaseDate || "No disponible",
-          whereToWatch:
-            item.whereToWatch && item.whereToWatch.length > 0
-              ? item.whereToWatch
-              : ["No disponible"],
-          seasons: item.seasons,
-          source: "catalog",
-        })
-      }
-      onRemoveFavorite={(item) => removeFavorite(item.key)}
-      onOpenDetails={(item) =>
-        navigation.navigate("Details", {
-          id: item.key,
-          title: item.title,
-          mediaType: item.mediaType || "movie",
-          imageSrc: item.imageSrc,
-          description: item.description,
-          cast: item.cast,
-          releaseDate: item.releaseDate,
-          whereToWatch: item.whereToWatch,
-          seasons: item.seasons,
-          source: "catalog",
-        })
-      }
+      items={enrichedFavoriteItems}
+      currentIndex={clampedActiveIndex}
+      onOpenDetails={handleOpenDetails}
+      onMarkWatched={handleMarkWatchedAndAdvance}
+      onNavigateNext={handleNavigateNext}
+      onNavigatePrev={handleNavigatePrev}
+      activeSectionLabel={undefined}
     />
   );
 }


### PR DESCRIPTION
Closes #69

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Replaces Home browsing with an actionable favorites-only poster queue.
- Adds real watched/not-watched actions for movies and episode progress behavior for series.
- Fixes follow-up route/layout issues for Details, EpisodeList, and Search Results.

## Changes
| File | Change |
|------|--------|
| `containers/HomeContainer.tsx` | Builds the favorite-only actionable queue, hydrates series details when needed, and persists watched mutations. |
| `components/views/PosterQueue*.tsx` | Adds poster queue types, gesture classification, and full-screen poster presentation. |
| `app/tabs/_layout.tsx`, `containers/FavoritesContainer.tsx` | Moves the add FAB from global tab layout to Favorites only. |
| `containers/DetailsContainer.tsx`, `components/views/DetailsView.tsx`, `components/ui/IconSymbol.tsx` | Adds movie watched toggle and removes duplicate Details top border. |
| `containers/EpisodeListContainer.tsx`, `components/views/EpisodeListView.tsx` | Opens on the current/next unwatched season and keeps the selector as an overlay. |
| `app/home/search/query.tsx` | Applies the existing route scroll pattern to Search Results. |

## Review Workload
- size:exception approved by maintainer in chat for a single PR.
- Changed lines exceed the normal 400-line budget, but the branch was split into four work-unit commits.

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] Scoped ESLint for all touched TypeScript/TSX files
- [x] Package manifests remained clean
- [x] Fresh static PR-readiness review passed
- [ ] Manually retest on device/browser: Home queue, Details watched toggle, EpisodeList selector, Search Results scroll

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated if behavior changed or not needed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
