### PR TITLE
fix(home): add watched toast undo action

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,9 +10,9 @@ import { createStackNavigator } from "@react-navigation/stack";
 import type { StackNavigationProp } from "@react-navigation/stack";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { useFonts } from "expo-font";
-import { View, Text } from "react-native";
+import { View, Text, Pressable } from "react-native";
 import Toast from "react-native-toast-message";
-import type { ToastConfig } from "react-native-toast-message";
+import type { ToastConfig, ToastConfigParams } from "react-native-toast-message";
 import "react-native-reanimated";
 
 import { HeaderContainer } from "@/containers/HeaderContainer";
@@ -31,6 +31,10 @@ import type { RootStackParamList } from "./navigation/types";
 interface ToastInfoProps {
   text1?: string;
   text2?: string;
+}
+
+interface UndoToastPayload {
+  onUndo?: () => void;
 }
 
 function ThemedToast(): ReactElement {
@@ -81,6 +85,76 @@ function ThemedToast(): ReactElement {
           </Text>
         </View>
       ),
+      success: ({ text1, text2, props }: ToastConfigParams<UndoToastPayload>) => {
+        const onUndo = props?.onUndo;
+        return (
+          <View
+            style={{
+              backgroundColor: palette.shellSurface,
+              borderLeftColor: "#4CAF50",
+              borderLeftWidth: 5,
+              borderWidth: 1,
+              borderColor: palette.shellBorder,
+              padding: 15,
+              marginHorizontal: 20,
+              borderRadius: 8,
+              shadowColor: "#000",
+              shadowOffset: { width: 0, height: 2 },
+              shadowOpacity: 0.35,
+              shadowRadius: 4,
+              elevation: 5,
+              alignSelf: "center",
+              width: "90%",
+              maxWidth: 400,
+              flexDirection: "row",
+              alignItems: "center",
+            }}
+          >
+            <View style={{ flex: 1, marginRight: 10 }}>
+              <Text
+                style={{
+                  color: palette.text,
+                  fontSize: 16,
+                  fontWeight: "bold",
+                }}
+                numberOfLines={1}
+              >
+                {text1}
+              </Text>
+              {text2 ? (
+                <Text
+                  style={{
+                    color: palette.shellMutedText,
+                    fontSize: 14,
+                    marginTop: 2,
+                  }}
+                  numberOfLines={1}
+                >
+                  {text2}
+                </Text>
+              ) : null}
+            </View>
+            {onUndo ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Undo watched action"
+                onPress={onUndo}
+                style={{ paddingVertical: 6, paddingHorizontal: 12 }}
+              >
+                <Text
+                  style={{
+                    color: "#fff",
+                    fontSize: 15,
+                    fontWeight: "600",
+                  }}
+                >
+                  Undo
+                </Text>
+              </Pressable>
+            ) : null}
+          </View>
+        );
+      },
     }),
     [palette]
   );

--- a/containers/HomeContainer.tsx
+++ b/containers/HomeContainer.tsx
@@ -243,6 +243,34 @@ export function HomeContainer(): ReactElement {
     },
   });
 
+  const undoMovieWatchedMutation = useMutation({
+    mutationFn: (mediaId: string) => watchedProgressRepository.setMovieWatched(mediaId, false),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["watched-progress"] });
+    },
+    onError: (err) => {
+      console.error("[HomeContainer] undoMovieWatched failed:", err);
+      Toast.show({ type: "error", text1: "Failed to undo. Please try again." });
+    },
+  });
+
+  const undoEpisodeWatchedMutation = useMutation({
+    mutationFn: (input: { mediaId: string; seasonNumber: number; episodeNumber: number }) =>
+      watchedProgressRepository.setEpisodeWatched({
+        mediaId: input.mediaId,
+        seasonNumber: input.seasonNumber,
+        episodeNumber: input.episodeNumber,
+        watched: false,
+      }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["watched-progress"] });
+    },
+    onError: (err) => {
+      console.error("[HomeContainer] undoEpisodeWatched failed:", err);
+      Toast.show({ type: "error", text1: "Failed to undo. Please try again." });
+    },
+  });
+
   const handleOpenDetails = useCallback(
     (item: PosterQueueItem): void => {
       navigation.navigate("Details", {
@@ -301,13 +329,37 @@ export function HomeContainer(): ReactElement {
             text2: enriched.nextEpisodeLabel ? `Next: ${enriched.nextEpisodeLabel}` : "All episodes watched",
             visibilityTime: 2500,
             position: "bottom",
+            props: {
+              onUndo: () => {
+                if (enriched.currentEpisode) {
+                  undoEpisodeWatchedMutation.mutate({
+                    mediaId: enriched.key,
+                    seasonNumber: enriched.currentEpisode.seasonNumber,
+                    episodeNumber: enriched.currentEpisode.episodeNumber,
+                  });
+                }
+              },
+            },
+          });
+        } else if (enriched.mediaType === "movie") {
+          Toast.show({
+            type: "success",
+            text1: `Marked: ${watchedLabel}`,
+            text2: undefined,
+            visibilityTime: 2500,
+            position: "bottom",
+            props: {
+              onUndo: () => {
+                undoMovieWatchedMutation.mutate(enriched.key);
+              },
+            },
           });
         }
       } catch {
         // mutation error already handled in onError — do not advance
       }
     },
-    [handleMarkWatchedAsync],
+    [handleMarkWatchedAsync, undoEpisodeWatchedMutation, undoMovieWatchedMutation],
   );
 
   const isLoading = isLoadingFavorites;


### PR DESCRIPTION
Closes #71
Closes #72

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Shows a bottom success toast when a Home poster queue movie is swiped as watched.
- Adds a right-side Undo action to watched success toasts for movies and episodes.
- Routes Undo callbacks through `react-native-toast-message` custom `props` so the CTA renders and reverts watched state.

## Changes
| File | Change |
|------|--------|
| `app/_layout.tsx` | Adds custom success toast rendering with accessible white Undo CTA. |
| `containers/HomeContainer.tsx` | Adds movie success toast, undo mutations, and toast `props.onUndo` callbacks for movies/episodes. |

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/eslint app/_layout.tsx containers/HomeContainer.tsx`
- [x] `git status --short -- package.json pnpm-lock.yaml`
- [x] Fresh static review passed
- [ ] Manually retest: swipe movie/episode as watched, confirm bottom toast shows white Undo, tap Undo and verify watched state reverts

## Contributor Checklist
- [x] Linked approved issues
- [x] Added exactly one `type:*` label
- [x] Docs updated if behavior changed or not needed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
