### PR TITLE
feat(home): auto-favorite watched items

### DIFF
--- a/containers/DetailsContainer.tsx
+++ b/containers/DetailsContainer.tsx
@@ -241,7 +241,22 @@ export function DetailsContainer({ params }: DetailsContainerProps): ReactElemen
     if (watchedMovieStatus?.watched) {
       void toggleWatchedMutation.mutateAsync(false);
     } else {
-      void toggleWatchedMutation.mutateAsync(true);
+      void toggleWatchedMutation.mutateAsync(true).then(() => {
+        if (mediaType === "movie" && !isFavorite) {
+          addFavorite({
+            id: params.id,
+            title,
+            mediaType,
+            url: imageSrc,
+            description: description || "Not available",
+            cast: cast && cast.length > 0 ? cast : ["Not available"],
+            releaseDate: releaseDate || "Not available",
+            whereToWatch: whereToWatch && whereToWatch.length > 0 ? whereToWatch : ["Not available"],
+            seasons: seasons,
+            source: "catalog",
+          });
+        }
+      });
     }
   };
 

--- a/containers/EpisodeListContainer.tsx
+++ b/containers/EpisodeListContainer.tsx
@@ -8,6 +8,7 @@ import { queryOptions } from "@/constants/query";
 import { SeasonSchema } from "@/domain/entities/Movie";
 import { createEpisodeWatchedKey, type WatchedEpisodeInput } from "@/domain/entities/WatchedProgress";
 import { useRepositories } from "@/providers/RepositoryProvider";
+import { useFavoriteMutations } from "@/hooks/useFavoriteMutations";
 
 interface EpisodeListContainerProps {
   params: RootStackParamList["EpisodeList"];
@@ -40,8 +41,9 @@ function getSeasonLabel(season: NonNullable<RootStackParamList["EpisodeList"]["s
 }
 
 export function EpisodeListContainer({ params }: EpisodeListContainerProps): ReactElement {
-  const { movieRepository, watchedProgressRepository } = useRepositories();
+  const { movieRepository, watchedProgressRepository, favoriteRepository } = useRepositories();
   const queryClient = useQueryClient();
+  const { addFavorite } = useFavoriteMutations();
   const needsDetailsFallback = !params.title || !params.seasons || params.seasons.length === 0;
   const { data: details } = useQuery({
     queryKey: ["movies", "details", params.id],
@@ -59,7 +61,7 @@ export function EpisodeListContainer({ params }: EpisodeListContainerProps): Rea
   });
 
   const toggleEpisodeWatchedMutation = useMutation({
-    mutationFn: (input: EpisodeToggleInput) => {
+    mutationFn: async (input: EpisodeToggleInput) => {
       const watchedInput: WatchedEpisodeInput = {
         mediaId: params.id,
         ...input,
@@ -67,9 +69,27 @@ export function EpisodeListContainer({ params }: EpisodeListContainerProps): Rea
 
       return watchedProgressRepository.setEpisodeWatched(watchedInput);
     },
-    onSuccess: () => {
+    onSuccess: (_data, input) => {
       void queryClient.invalidateQueries(queryOptions.watchedProgress.episodes(params.id));
       void queryClient.invalidateQueries({ queryKey: ["watched-progress", "summary"] });
+      if (input.watched) {
+        void favoriteRepository.exists(params.id).then((exists) => {
+          if (!exists) {
+            addFavorite({
+              id: params.id,
+              title: title,
+              mediaType: "series",
+              url: details?.primaryImage?.url,
+              description: details?.plot || "Not available",
+              cast: details?.cast ?? ["Not available"],
+              releaseDate: details?.releaseDate || details?.startYear?.toString() || "Not available",
+              whereToWatch: details?.whereToWatch ?? ["Not available"],
+              seasons: seasons,
+              source: "catalog",
+            });
+          }
+        });
+      }
     },
   });
 

--- a/containers/HomeContainer.tsx
+++ b/containers/HomeContainer.tsx
@@ -123,6 +123,42 @@ export function HomeContainer(): ReactElement {
     enabled: favoriteIds.length > 0,
   });
 
+  const watchedShowIdsQuery = useQuery({
+    queryKey: ["watched-progress", "shows", "home-queue"],
+    queryFn: () => watchedProgressRepository.getAllWatchedShows(),
+  });
+
+  const nonFavoriteWatchedShowIds = useMemo(() => {
+    const watchedShows = watchedShowIdsQuery.data ?? [];
+    return watchedShows.filter((id) => !favoriteIds.includes(id));
+  }, [watchedShowIdsQuery.data, favoriteIds]);
+
+  const nonFavoriteWatchedShowsQuery = useQuery({
+    queryKey: ["home-watched-shows", [...nonFavoriteWatchedShowIds].sort()],
+    queryFn: async (): Promise<Record<string, { id: string; title: string; url?: string; seasons?: Season[] }>> => {
+      const results: Record<string, { id: string; title: string; url?: string; seasons?: Season[] }> = {};
+      await Promise.all(
+        nonFavoriteWatchedShowIds.map(async (id) => {
+          try {
+            const details = await movieRepository.getById(id);
+            if (details) {
+              results[id] = {
+                id: details.id,
+                title: details.primaryTitle,
+                url: details.primaryImage?.url,
+                seasons: details.seasons,
+              };
+            }
+          } catch {
+            // Non-blocking: skip shows that can't be fetched
+          }
+        }),
+      );
+      return results;
+    },
+    enabled: nonFavoriteWatchedShowIds.length > 0,
+  });
+
   const enrichedFavoriteItems = useMemo((): EnrichedFavoriteItem[] => {
     return favoriteItems
       .filter((item): boolean => {
@@ -208,12 +244,105 @@ export function HomeContainer(): ReactElement {
       });
   }, [favoriteItems, movieWatchStatusQuery.data, episodeStatusQueries.data, seriesDetailsHydration.data]);
 
+  const watchedShowEpisodeStatusesQuery = useQuery({
+    queryKey: ["watched-progress", "episodes", "home-watched-shows", [...nonFavoriteWatchedShowIds].sort()],
+    queryFn: async () => {
+      const results: Record<string, { seasonNumber: number; episodeNumber: number; watched: boolean; title?: string }[]> = {};
+      await Promise.all(
+        nonFavoriteWatchedShowIds.map(async (id) => {
+          const episodes = await watchedProgressRepository.getEpisodeStatuses(id);
+          results[id] = episodes;
+        }),
+      );
+      return results;
+    },
+    enabled: nonFavoriteWatchedShowIds.length > 0,
+  });
+
+  const watchedShowItems = useMemo((): EnrichedFavoriteItem[] => {
+    if (!nonFavoriteWatchedShowsQuery.data || !watchedShowEpisodeStatusesQuery.data) {
+      return [];
+    }
+
+    return Object.entries(nonFavoriteWatchedShowsQuery.data).map(([id, show]) => {
+      const seasons = show.seasons ?? [];
+      const episodes = watchedShowEpisodeStatusesQuery.data[id] ?? [];
+      const watchedKeys = new Set(
+        episodes.filter((e) => e.watched).map((e) => createEpisodeWatchedKey(e.seasonNumber, e.episodeNumber))
+      );
+
+      let totalEpisodes = 0;
+      let watchedEpisodes = 0;
+      let firstUnwatched: { seasonNumber: number; episodeNumber: number; title?: string } | undefined;
+      let nextUnwatched: { seasonNumber: number; episodeNumber: number; title?: string } | undefined;
+      let foundFirst = false;
+
+      for (const season of seasons) {
+        for (const episode of season.episodes) {
+          totalEpisodes++;
+          const key = createEpisodeWatchedKey(season.seasonNumber, episode.episodeNumber);
+          if (watchedKeys.has(key)) {
+            watchedEpisodes++;
+          } else {
+            if (!foundFirst) {
+              firstUnwatched = { seasonNumber: season.seasonNumber, episodeNumber: episode.episodeNumber, title: episode.title };
+              foundFirst = true;
+            } else if (!nextUnwatched) {
+              nextUnwatched = { seasonNumber: season.seasonNumber, episodeNumber: episode.episodeNumber, title: episode.title };
+            }
+          }
+        }
+      }
+
+      const currentEpisode: CurrentEpisodeInfo | undefined = firstUnwatched
+        ? {
+            seasonNumber: firstUnwatched.seasonNumber,
+            episodeNumber: firstUnwatched.episodeNumber,
+            title: firstUnwatched.title,
+            label: `S${firstUnwatched.seasonNumber}E${firstUnwatched.episodeNumber}${firstUnwatched.title ? ` \u2022 ${firstUnwatched.title}` : ""}`,
+          }
+        : undefined;
+
+      return {
+        key: id,
+        imageSrc: show.url,
+        title: show.title,
+        mediaType: "series" as const,
+        description: undefined,
+        cast: undefined,
+        releaseDate: undefined,
+        whereToWatch: undefined,
+        seasons: show.seasons,
+        source: "catalog" as const,
+        watchStatus: "watched" as const,
+        currentEpisode,
+        watchedCount: watchedEpisodes,
+        totalCount: totalEpisodes,
+        progressLabel: `${watchedEpisodes} / ${totalEpisodes} Episodes`,
+        progressPercent: totalEpisodes > 0 ? Math.round((watchedEpisodes / totalEpisodes) * 100) : 0,
+        nextEpisodeLabel: nextUnwatched
+          ? `S${nextUnwatched.seasonNumber}E${nextUnwatched.episodeNumber}${nextUnwatched.title ? ` \u2022 ${nextUnwatched.title}` : ""}`
+          : undefined,
+      };
+    }).filter((item) => {
+      if (item.totalCount > 0 && item.watchedCount === item.totalCount) {
+        return false;
+      }
+      return true;
+    });
+  }, [nonFavoriteWatchedShowsQuery.data, watchedShowEpisodeStatusesQuery.data]);
+
+  const allHomeItems = useMemo(
+    () => [...enrichedFavoriteItems, ...watchedShowItems],
+    [enrichedFavoriteItems, watchedShowItems],
+  );
+
   const [activeFavoriteIndex, setActiveFavoriteIndex] = useState(0);
 
   const clampedActiveIndex = useMemo(() => {
-    if (enrichedFavoriteItems.length === 0) return 0;
-    return Math.min(Math.max(0, activeFavoriteIndex), enrichedFavoriteItems.length - 1);
-  }, [activeFavoriteIndex, enrichedFavoriteItems.length]);
+    if (allHomeItems.length === 0) return 0;
+    return Math.min(Math.max(0, activeFavoriteIndex), allHomeItems.length - 1);
+  }, [activeFavoriteIndex, allHomeItems.length]);
 
   const markMovieWatchedMutation = useMutation({
     mutationFn: (mediaId: string) => watchedProgressRepository.setMovieWatched(mediaId, true),
@@ -223,6 +352,27 @@ export function HomeContainer(): ReactElement {
     onError: (err) => {
       console.error("[HomeContainer] markMovieWatched failed:", err);
       Toast.show({ type: "error", text1: "Failed to mark as watched. Please try again." });
+    },
+  });
+
+  const autoFavoriteMutation = useMutation({
+    mutationFn: async (input: { id: string; title: string; mediaType: "movie" | "series"; url?: string }) => {
+      const exists = await favoriteRepository.exists(input.id);
+      if (!exists) {
+        await favoriteRepository.add({
+          id: input.id,
+          title: input.title,
+          mediaType: input.mediaType,
+          url: input.url,
+          source: "catalog",
+        });
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryOptions.movies.favorites.queryKey });
+    },
+    onError: (err) => {
+      console.error("[HomeContainer] autoFavorite failed:", err);
     },
   });
 
@@ -298,23 +448,35 @@ export function HomeContainer(): ReactElement {
           seasonNumber,
           episodeNumber,
         });
+        await autoFavoriteMutation.mutateAsync({
+          id: item.key,
+          title: item.title,
+          mediaType: "series",
+          url: item.imageSrc,
+        });
       } else if (item.mediaType === "movie") {
         await markMovieWatchedMutation.mutateAsync(item.key);
+        await autoFavoriteMutation.mutateAsync({
+          id: item.key,
+          title: item.title,
+          mediaType: "movie",
+          url: item.imageSrc,
+        });
       }
       return true;
     },
-    [markEpisodeWatchedMutation, markMovieWatchedMutation],
+    [markEpisodeWatchedMutation, markMovieWatchedMutation, autoFavoriteMutation],
   );
 
   const handleNavigateNext = useCallback((): void => {
-    if (enrichedFavoriteItems.length === 0) return;
-    setActiveFavoriteIndex((prev) => (prev + 1) % enrichedFavoriteItems.length);
-  }, [enrichedFavoriteItems.length]);
+    if (allHomeItems.length === 0) return;
+    setActiveFavoriteIndex((prev) => (prev + 1) % allHomeItems.length);
+  }, [allHomeItems.length]);
 
   const handleNavigatePrev = useCallback((): void => {
-    if (enrichedFavoriteItems.length === 0) return;
-    setActiveFavoriteIndex((prev) => (prev - 1 + enrichedFavoriteItems.length) % enrichedFavoriteItems.length);
-  }, [enrichedFavoriteItems.length]);
+    if (allHomeItems.length === 0) return;
+    setActiveFavoriteIndex((prev) => (prev - 1 + allHomeItems.length) % allHomeItems.length);
+  }, [allHomeItems.length]);
 
   const handleMarkWatchedAndAdvance = useCallback(
     async (item: PosterQueueItem): Promise<void> => {
@@ -369,7 +531,7 @@ export function HomeContainer(): ReactElement {
     <PosterQueueView
       isLoading={isLoading}
       errorMessage={error?.message}
-      items={enrichedFavoriteItems}
+      items={allHomeItems}
       currentIndex={clampedActiveIndex}
       onOpenDetails={handleOpenDetails}
       onMarkWatched={handleMarkWatchedAndAdvance}

--- a/src/domain/repositories/IWatchedProgressRepository.ts
+++ b/src/domain/repositories/IWatchedProgressRepository.ts
@@ -14,4 +14,6 @@ export interface IWatchedProgressRepository {
   setEpisodeWatched(input: WatchedEpisodeInput): Promise<WatchedEpisode>;
 
   clearMediaProgress(mediaId: string): Promise<void>;
+
+  getAllWatchedShows(): Promise<string[]>;
 }

--- a/src/repositories/AsyncStorageWatchedProgressRepository.ts
+++ b/src/repositories/AsyncStorageWatchedProgressRepository.ts
@@ -89,6 +89,16 @@ export class AsyncStorageWatchedProgressRepository implements IWatchedProgressRe
     await this.writeStore(nextStore);
   }
 
+  async getAllWatchedShows(): Promise<string[]> {
+    const store = await this.readStore();
+    const showIds = new Set(
+      store.episodes
+        .filter((episode) => episode.watched)
+        .map((episode) => episode.mediaId)
+    );
+    return Array.from(showIds);
+  }
+
   private async readStore(): Promise<WatchedProgressStore> {
     const storage = await AsyncStorage.getItem(STORAGE_KEY);
 


### PR DESCRIPTION
Closes #74

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Includes non-favorite shows on Home when they have at least one watched episode.
- Auto-favorites non-favorite movies or parent shows when users mark a movie/episode as watched.
- Preserves Undo/watched=false behavior without removing favorites.

## Changes
| File | Change |
|------|--------|
| `containers/HomeContainer.tsx` | Combines favorites with watched shows and auto-favorites watched items from Home. |
| `containers/DetailsContainer.tsx` | Auto-favorites non-favorite movies when marked watched from Details. |
| `containers/EpisodeListContainer.tsx` | Auto-favorites parent shows when episodes are marked watched. |
| `src/domain/repositories/IWatchedProgressRepository.ts` | Adds watched-show lookup contract. |
| `src/repositories/AsyncStorageWatchedProgressRepository.ts` | Returns show IDs with at least one watched episode. |

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/eslint containers/HomeContainer.tsx containers/DetailsContainer.tsx containers/EpisodeListContainer.tsx src/domain/repositories/IWatchedProgressRepository.ts src/repositories/AsyncStorageWatchedProgressRepository.ts`
- [x] `git status --short -- package.json pnpm-lock.yaml`
- [x] Fresh static review passed
- [ ] Manually retest: mark non-favorite movie watched, mark non-favorite episode watched, confirm auto-favorite and Home inclusion

## Contributor Checklist
- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated if behavior changed or not needed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
